### PR TITLE
Stub demo_simulator in OpenAPI export to fix CI build

### DIFF
--- a/services/fleet-manager/export_openapi.py
+++ b/services/fleet-manager/export_openapi.py
@@ -73,6 +73,14 @@ rc_mod.close_redis = None
 rc_mod.get_redis = lambda: None
 sys.modules["redis_client"] = rc_mod
 
+# demo_simulator.py — depends on nats which is not installed in CI
+ds_mod = types.ModuleType("demo_simulator")
+ds_mod.demo_simulator = type("DS", (), {
+    "start": lambda s, *a, **kw: None,
+    "stop": lambda s, *a, **kw: None,
+})()
+sys.modules["demo_simulator"] = ds_mod
+
 # ---------------------------------------------------------------------------
 # Import the app and dump the spec.
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Changes

Adds a stub module for `demo_simulator` in the OpenAPI export script to resolve CI build failures.

### Details

- Creates a mock `demo_simulator` module with stubbed `start()` and `stop()` methods
- Prevents import errors caused by missing `nats` dependency in CI environment
- Similar approach to existing `redis_client` module stubbing

This allows the OpenAPI spec export to complete successfully without requiring the full `nats` dependency in CI.