### PR TITLE
Add zeroconf/mDNS device discovery and provisioning

### DIFF
--- a/config/postgres/init/01-init-db.sql
+++ b/config/postgres/init/01-init-db.sql
@@ -170,6 +170,37 @@ CREATE TABLE IF NOT EXISTS users (
 );
 
 -- =============================================================================
+-- DEVICE DISCOVERY & PROVISIONING
+-- =============================================================================
+
+-- Blocked devices - Hardware IDs that should be rejected on discovery
+CREATE TABLE IF NOT EXISTS blocked_devices (
+    id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+    hardware_id VARCHAR(255) UNIQUE NOT NULL,
+    reason TEXT,
+    blocked_at TIMESTAMPTZ DEFAULT NOW()
+);
+
+CREATE INDEX IF NOT EXISTS idx_blocked_devices_hardware_id ON blocked_devices(hardware_id);
+
+-- Device provisions - Provisioning config pushed to devices after approval
+CREATE TABLE IF NOT EXISTS device_provisions (
+    id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+    device_id UUID UNIQUE NOT NULL REFERENCES devices(id) ON DELETE CASCADE,
+    entity_id UUID REFERENCES entities(id) ON DELETE SET NULL,
+    env_vars JSONB DEFAULT '{}'::jsonb,
+    connection_config JSONB DEFAULT '{}'::jsonb,
+    provision_status VARCHAR(50) DEFAULT 'pending',  -- pending, approved, provisioned
+    approved_at TIMESTAMPTZ,
+    provisioned_at TIMESTAMPTZ,
+    created_at TIMESTAMPTZ DEFAULT NOW(),
+    updated_at TIMESTAMPTZ DEFAULT NOW()
+);
+
+CREATE INDEX IF NOT EXISTS idx_device_provisions_device_id ON device_provisions(device_id);
+CREATE INDEX IF NOT EXISTS idx_device_provisions_status ON device_provisions(provision_status);
+
+-- =============================================================================
 -- FUNCTIONS & TRIGGERS
 -- =============================================================================
 
@@ -190,6 +221,9 @@ CREATE TRIGGER update_device_groups_updated_at BEFORE UPDATE ON device_groups
     FOR EACH ROW EXECUTE FUNCTION update_updated_at_column();
 
 CREATE TRIGGER update_experiences_updated_at BEFORE UPDATE ON experiences
+    FOR EACH ROW EXECUTE FUNCTION update_updated_at_column();
+
+CREATE TRIGGER update_device_provisions_updated_at BEFORE UPDATE ON device_provisions
     FOR EACH ROW EXECUTE FUNCTION update_updated_at_column();
 
 -- =============================================================================

--- a/config/postgres/migrations/003_discovery.sql
+++ b/config/postgres/migrations/003_discovery.sql
@@ -1,0 +1,47 @@
+-- Migration 003: Device Discovery & Provisioning
+-- Adds tables for zeroconf/mDNS device discovery, approval queue, and provisioning
+
+-- =============================================================================
+-- BLOCKED DEVICES
+-- =============================================================================
+
+CREATE TABLE IF NOT EXISTS blocked_devices (
+    id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+    hardware_id VARCHAR(255) UNIQUE NOT NULL,
+    reason TEXT,
+    blocked_at TIMESTAMPTZ DEFAULT NOW()
+);
+
+CREATE INDEX IF NOT EXISTS idx_blocked_devices_hardware_id ON blocked_devices(hardware_id);
+
+-- =============================================================================
+-- DEVICE PROVISIONS
+-- =============================================================================
+
+CREATE TABLE IF NOT EXISTS device_provisions (
+    id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+    device_id UUID UNIQUE NOT NULL REFERENCES devices(id) ON DELETE CASCADE,
+    entity_id UUID REFERENCES entities(id) ON DELETE SET NULL,
+    env_vars JSONB DEFAULT '{}'::jsonb,
+    connection_config JSONB DEFAULT '{}'::jsonb,
+    provision_status VARCHAR(50) DEFAULT 'pending',  -- pending, approved, provisioned
+    approved_at TIMESTAMPTZ,
+    provisioned_at TIMESTAMPTZ,
+    created_at TIMESTAMPTZ DEFAULT NOW(),
+    updated_at TIMESTAMPTZ DEFAULT NOW()
+);
+
+CREATE INDEX IF NOT EXISTS idx_device_provisions_device_id ON device_provisions(device_id);
+CREATE INDEX IF NOT EXISTS idx_device_provisions_status ON device_provisions(provision_status);
+
+-- Apply the update_updated_at_column trigger (function defined in 01-init-db.sql)
+DO $$
+BEGIN
+    IF NOT EXISTS (
+        SELECT 1 FROM pg_trigger WHERE tgname = 'update_device_provisions_updated_at'
+    ) THEN
+        CREATE TRIGGER update_device_provisions_updated_at
+            BEFORE UPDATE ON device_provisions
+            FOR EACH ROW EXECUTE FUNCTION update_updated_at_column();
+    END IF;
+END $$;

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -164,10 +164,10 @@ services:
       dockerfile: Dockerfile
     container_name: maestra-dashboard
     environment:
-      - NEXT_PUBLIC_API_URL=http://10.0.0.199:8080
-      - NEXT_PUBLIC_NODERED_URL=http://10.0.0.199:1880
-      - NEXT_PUBLIC_GRAFANA_URL=http://10.0.0.199:3000
-      - NEXT_PUBLIC_MQTT_WS_URL=ws://10.0.0.199:9001
+      - NEXT_PUBLIC_API_URL=http://localhost:8080
+      - NEXT_PUBLIC_NODERED_URL=http://localhost:1880
+      - NEXT_PUBLIC_GRAFANA_URL=http://localhost:3000
+      - NEXT_PUBLIC_MQTT_WS_URL=ws://localhost:9001
     ports:
       - "3001:3000"
     volumes:
@@ -316,6 +316,30 @@ services:
     depends_on:
       - nats
       - mosquitto
+    restart: unless-stopped
+
+  # =============================================================================
+  # DEVICE DISCOVERY
+  # =============================================================================
+
+  # Discovery Service - mDNS/DNS-SD auto-detection of Maestra devices
+  discovery-service:
+    build:
+      context: ./services/discovery-service
+      dockerfile: Dockerfile
+    container_name: maestra-discovery
+    network_mode: host  # Required for mDNS multicast on the local network
+    environment:
+      - FLEET_MANAGER_URL=http://localhost:8080
+      - HOST_IP=${HOST_IP:-10.0.0.199}
+      - NATS_URL=nats://localhost:4222
+      - MQTT_BROKER=${HOST_IP:-10.0.0.199}
+      - MQTT_PORT=1883
+      - API_URL=http://${HOST_IP:-10.0.0.199}:8080
+      - WS_URL=ws://${HOST_IP:-10.0.0.199}:8765
+    depends_on:
+      fleet-manager:
+        condition: service_healthy
     restart: unless-stopped
 
 # =============================================================================

--- a/sdks/python/maestra/__init__.py
+++ b/sdks/python/maestra/__init__.py
@@ -41,4 +41,16 @@ __all__ = [
     "StreamSessionData",
     "StreamSessionHistoryData",
     "StreamRegistryStateData",
+    # Discovery (lazy imports - require zeroconf)
+    "discover_maestra",
+    "advertise_device",
+    "wait_for_provisioning",
 ]
+
+
+def __getattr__(name):
+    """Lazy import discovery functions to avoid requiring zeroconf"""
+    if name in ("discover_maestra", "advertise_device", "wait_for_provisioning"):
+        from . import discovery
+        return getattr(discovery, name)
+    raise AttributeError(f"module 'maestra' has no attribute {name!r}")

--- a/sdks/python/maestra/client.py
+++ b/sdks/python/maestra/client.py
@@ -260,6 +260,26 @@ class MaestraClient:
         self._subscribed_entities: Dict[str, Entity] = {}
         self._client_id = self.config.client_id or f"maestra-py-{uuid.uuid4().hex[:8]}"
 
+    @classmethod
+    async def discover(cls, timeout: float = 5.0) -> "MaestraClient":
+        """
+        Discover a Maestra server on the local network via mDNS and create a connected client.
+
+        Usage:
+            client = await MaestraClient.discover()
+
+        Args:
+            timeout: How long to wait for mDNS discovery (seconds)
+
+        Returns:
+            A connected MaestraClient instance
+        """
+        from .discovery import discover_maestra
+        config = await discover_maestra(timeout=timeout)
+        client = cls(config)
+        await client.connect()
+        return client
+
     async def connect(self) -> None:
         """Connect to Maestra services"""
         # HTTP is always available

--- a/sdks/python/maestra/discovery.py
+++ b/sdks/python/maestra/discovery.py
@@ -1,0 +1,214 @@
+"""
+Maestra Discovery - mDNS/DNS-SD helpers for automatic service discovery
+
+Requires the 'zeroconf' package: pip install maestra[discovery]
+"""
+
+import asyncio
+import socket
+import logging
+from typing import Optional
+
+from .types import ConnectionConfig
+
+log = logging.getLogger("maestra.discovery")
+
+# Service types
+SERVER_SERVICE_TYPE = "_maestra._tcp.local."
+DEVICE_SERVICE_TYPE = "_maestra-device._tcp.local."
+
+
+async def discover_maestra(timeout: float = 5.0) -> ConnectionConfig:
+    """
+    Discover a Maestra server on the local network via mDNS.
+
+    Browses for _maestra._tcp.local. and extracts connection details
+    from the TXT records.
+
+    Args:
+        timeout: How long to wait for discovery (seconds)
+
+    Returns:
+        ConnectionConfig populated with discovered server details
+
+    Raises:
+        ImportError: If zeroconf is not installed
+        TimeoutError: If no Maestra server found within timeout
+    """
+    try:
+        from zeroconf import Zeroconf, ServiceBrowser, ServiceInfo
+    except ImportError:
+        raise ImportError(
+            "zeroconf is required for discovery. "
+            "Install it with: pip install maestra[discovery]"
+        )
+
+    found_config = None
+    event = asyncio.Event()
+
+    class Listener:
+        def add_service(self, zc: Zeroconf, type_: str, name: str) -> None:
+            nonlocal found_config
+            info = ServiceInfo(type_, name)
+            if info.request(zc, 3000):
+                props = {}
+                if info.properties:
+                    for k, v in info.properties.items():
+                        key = k.decode("utf-8") if isinstance(k, bytes) else k
+                        val = v.decode("utf-8") if isinstance(v, bytes) else str(v)
+                        props[key] = val
+
+                found_config = ConnectionConfig(
+                    api_url=props.get("api_url", f"http://{_get_ip(info)}:8080"),
+                    nats_url=props.get("nats_url", f"nats://{_get_ip(info)}:4222"),
+                    mqtt_broker=props.get("mqtt_broker", _get_ip(info)),
+                    mqtt_port=int(props.get("mqtt_port", "1883")),
+                )
+                log.info(f"Discovered Maestra at {found_config.api_url}")
+                event.set()
+
+        def remove_service(self, zc, type_, name):
+            pass
+
+        def update_service(self, zc, type_, name):
+            pass
+
+    zc = Zeroconf()
+    try:
+        browser = ServiceBrowser(zc, SERVER_SERVICE_TYPE, Listener())
+        try:
+            await asyncio.wait_for(event.wait(), timeout=timeout)
+        except asyncio.TimeoutError:
+            raise TimeoutError(
+                f"No Maestra server found within {timeout}s. "
+                "Ensure the discovery service is running."
+            )
+        return found_config
+    finally:
+        zc.close()
+
+
+async def advertise_device(
+    hardware_id: str,
+    device_type: str,
+    name: str,
+    port: int = 0,
+    firmware_version: Optional[str] = None,
+):
+    """
+    Advertise this device on the network as _maestra-device._tcp.local.
+    The Maestra discovery service will detect this and register it as pending.
+
+    Args:
+        hardware_id: Unique device identifier (MAC address, serial, etc.)
+        device_type: Device type (e.g., 'esp32', 'raspberry_pi')
+        name: Human-readable device name
+        port: Service port (0 if not applicable)
+        firmware_version: Optional firmware version string
+
+    Returns:
+        A tuple of (Zeroconf, ServiceInfo) — call zc.unregister_service(info)
+        and zc.close() when done.
+    """
+    try:
+        from zeroconf import Zeroconf, ServiceInfo
+    except ImportError:
+        raise ImportError(
+            "zeroconf is required for discovery. "
+            "Install it with: pip install maestra[discovery]"
+        )
+
+    properties = {
+        "hardware_id": hardware_id,
+        "device_type": device_type,
+        "name": name,
+    }
+    if firmware_version:
+        properties["firmware_version"] = firmware_version
+
+    # Get local IP
+    local_ip = _get_local_ip()
+    ip_bytes = socket.inet_aton(local_ip)
+
+    service_name = f"{name.replace(' ', '-')}.{DEVICE_SERVICE_TYPE}"
+    info = ServiceInfo(
+        DEVICE_SERVICE_TYPE,
+        service_name,
+        addresses=[ip_bytes],
+        port=port,
+        properties=properties,
+        server=f"{name.replace(' ', '-')}.local.",
+    )
+
+    zc = Zeroconf()
+    zc.register_service(info)
+    log.info(f"Advertising device '{name}' ({hardware_id}) as {DEVICE_SERVICE_TYPE}")
+
+    return zc, info
+
+
+async def wait_for_provisioning(
+    api_url: str,
+    device_id: str,
+    poll_interval: float = 5.0,
+    timeout: float = 300.0,
+) -> dict:
+    """
+    Poll the Fleet Manager for provisioning config until the device is approved.
+
+    Args:
+        api_url: Fleet Manager API URL
+        device_id: Device UUID from registration
+        poll_interval: Seconds between polling attempts
+        timeout: Maximum time to wait (seconds)
+
+    Returns:
+        Provisioning config dict with connection details and env vars
+
+    Raises:
+        TimeoutError: If not approved within timeout
+    """
+    import aiohttp
+
+    url = f"{api_url.rstrip('/')}/devices/{device_id}/provision"
+    elapsed = 0.0
+
+    async with aiohttp.ClientSession() as session:
+        while elapsed < timeout:
+            try:
+                async with session.get(url) as response:
+                    if response.status == 200:
+                        data = await response.json()
+                        log.info(f"Device provisioned: {data.get('provision_status')}")
+                        return data
+                    elif response.status == 403:
+                        # Not approved yet
+                        log.debug("Device not yet approved, waiting...")
+                    else:
+                        log.warning(f"Provision check returned {response.status}")
+            except Exception as e:
+                log.debug(f"Provision check failed: {e}")
+
+            await asyncio.sleep(poll_interval)
+            elapsed += poll_interval
+
+    raise TimeoutError(f"Device not provisioned within {timeout}s")
+
+
+def _get_ip(info) -> str:
+    """Extract IP address from ServiceInfo"""
+    if info.addresses:
+        return socket.inet_ntoa(info.addresses[0])
+    return "localhost"
+
+
+def _get_local_ip() -> str:
+    """Get the local IP address of this machine"""
+    try:
+        s = socket.socket(socket.AF_INET, socket.SOCK_DGRAM)
+        s.connect(("8.8.8.8", 80))
+        ip = s.getsockname()[0]
+        s.close()
+        return ip
+    except Exception:
+        return "127.0.0.1"

--- a/sdks/python/pyproject.toml
+++ b/sdks/python/pyproject.toml
@@ -32,9 +32,11 @@ dependencies = [
 [project.optional-dependencies]
 nats = ["nats-py>=2.6.0"]
 mqtt = ["paho-mqtt>=2.0.0"]
+discovery = ["zeroconf>=0.131.0"]
 all = [
     "nats-py>=2.6.0",
     "paho-mqtt>=2.0.0",
+    "zeroconf>=0.131.0",
 ]
 dev = [
     "pytest>=7.0.0",

--- a/services/dashboard/src/app/devices/page.tsx
+++ b/services/dashboard/src/app/devices/page.tsx
@@ -1,12 +1,15 @@
 'use client'
 
 import { useState } from 'react'
-import Link from 'next/link'
 import { useDevices, useFleetStats } from '@/hooks/useDevices'
+import { usePendingDevices, useBlockedDevices } from '@/hooks/useDiscovery'
 import { useToast } from '@/components/Toast'
 import { Card } from '@/components/Card'
 import { StatsCard } from '@/components/StatsCard'
 import { DeviceCard } from '@/components/DeviceCard'
+import { PendingDeviceCard } from '@/components/PendingDeviceCard'
+import { ApproveDeviceModal } from '@/components/ApproveDeviceModal'
+import { BlockedDevicesList } from '@/components/BlockedDevicesList'
 import {
   Activity,
   CheckCircle2,
@@ -15,21 +18,26 @@ import {
   Plus,
   Search,
   Monitor,
-  DEVICE_TYPE_ICONS,
 } from '@/components/icons'
 import { EmptyState } from '@/components/EmptyState'
-import { devicesApi } from '@/lib/api'
-import type { Device } from '@/lib/types'
+import { devicesApi, discoveryApi } from '@/lib/api'
+import type { Device, DeviceApproval } from '@/lib/types'
+
+type Tab = 'active' | 'pending' | 'blocked'
 
 export default function DevicesPage() {
   const { devices, loading, error, refresh } = useDevices(true, 10000)
+  const { devices: pendingDevices, refresh: refreshPending } = usePendingDevices(true, 5000)
+  const { devices: blockedDevices, refresh: refreshBlocked } = useBlockedDevices()
   const stats = useFleetStats(devices)
   const { toast, confirm } = useToast()
 
+  const [activeTab, setActiveTab] = useState<Tab>('active')
   const [showRegisterForm, setShowRegisterForm] = useState(false)
   const [searchQuery, setSearchQuery] = useState('')
   const [filterType, setFilterType] = useState('')
   const [filterStatus, setFilterStatus] = useState('')
+  const [approveDevice, setApproveDevice] = useState<Device | null>(null)
   const [registerForm, setRegisterForm] = useState({
     name: '',
     device_type: 'arduino',
@@ -67,14 +75,85 @@ export default function DevicesPage() {
     }
   }
 
-  const filteredDevices = devices.filter((d) => {
+  const handleApproveConfirm = async (device: Device, approval: DeviceApproval) => {
+    try {
+      await discoveryApi.approve(device.id, approval)
+      setApproveDevice(null)
+      refreshPending()
+      refresh()
+      toast({ message: `Device "${device.name}" approved`, type: 'success' })
+    } catch (err) {
+      toast({ message: `Failed to approve device: ${err instanceof Error ? err.message : 'Unknown error'}`, type: 'error' })
+    }
+  }
+
+  const handleReject = async (device: Device) => {
+    const ok = await confirm({
+      title: 'Reject Device',
+      message: `Reject device "${device.name}" (${device.hardware_id})? It will be removed from the pending list.`,
+      confirmLabel: 'Reject',
+      destructive: true,
+    })
+    if (!ok) return
+    try {
+      await discoveryApi.reject(device.id)
+      refreshPending()
+      toast({ message: `Device "${device.name}" rejected`, type: 'success' })
+    } catch (err) {
+      toast({ message: `Failed to reject device: ${err instanceof Error ? err.message : 'Unknown error'}`, type: 'error' })
+    }
+  }
+
+  const handleBlock = async (device: Device) => {
+    const ok = await confirm({
+      title: 'Block Device',
+      message: `Block device "${device.name}" (${device.hardware_id})? Its hardware ID will be permanently blocked from discovery.`,
+      confirmLabel: 'Block',
+      destructive: true,
+    })
+    if (!ok) return
+    try {
+      await discoveryApi.block(device.id)
+      refreshPending()
+      refreshBlocked()
+      toast({ message: `Device "${device.name}" blocked`, type: 'success' })
+    } catch (err) {
+      toast({ message: `Failed to block device: ${err instanceof Error ? err.message : 'Unknown error'}`, type: 'error' })
+    }
+  }
+
+  const handleUnblock = async (hardwareId: string) => {
+    const ok = await confirm({
+      title: 'Unblock Device',
+      message: `Unblock hardware ID "${hardwareId}"? This device will be able to appear in discovery again.`,
+      confirmLabel: 'Unblock',
+    })
+    if (!ok) return
+    try {
+      await discoveryApi.unblock(hardwareId)
+      refreshBlocked()
+      toast({ message: `Device unblocked`, type: 'success' })
+    } catch (err) {
+      toast({ message: `Failed to unblock device: ${err instanceof Error ? err.message : 'Unknown error'}`, type: 'error' })
+    }
+  }
+
+  // Filter active (non-pending) devices
+  const activeDevices = devices.filter(d => d.status !== 'pending')
+  const filteredDevices = activeDevices.filter((d) => {
     if (searchQuery && !d.name.toLowerCase().includes(searchQuery.toLowerCase())) return false
     if (filterType && d.device_type !== filterType) return false
     if (filterStatus && d.status !== filterStatus) return false
     return true
   })
 
-  const deviceTypes = [...new Set(devices.map((d) => d.device_type))]
+  const deviceTypes = [...new Set(activeDevices.map((d) => d.device_type))]
+
+  const tabs: { key: Tab; label: string; count?: number }[] = [
+    { key: 'active', label: 'Active', count: activeDevices.length },
+    { key: 'pending', label: 'Pending', count: pendingDevices.length },
+    { key: 'blocked', label: 'Blocked', count: blockedDevices.length },
+  ]
 
   return (
     <div className="min-h-full bg-gradient-to-br from-slate-900 to-slate-800 text-white">
@@ -84,7 +163,7 @@ export default function DevicesPage() {
           <div className="flex items-center justify-between">
             <div>
               <h1 className="text-2xl font-bold">Devices</h1>
-              <p className="text-sm text-slate-400 mt-1">Register and manage fleet devices</p>
+              <p className="text-sm text-slate-400 mt-1">Register, discover, and manage fleet devices</p>
             </div>
             <button
               onClick={() => setShowRegisterForm(!showRegisterForm)}
@@ -101,7 +180,7 @@ export default function DevicesPage() {
           <StatsCard title="Total Devices" value={stats.total} icon={Activity} />
           <StatsCard title="Online" value={stats.online} icon={CheckCircle2} />
           <StatsCard title="Offline" value={stats.offline} icon={PauseCircle} />
-          <StatsCard title="Errors" value={stats.error} icon={AlertTriangle} />
+          <StatsCard title="Pending" value={pendingDevices.length} icon={AlertTriangle} />
         </div>
 
         {/* Registration form */}
@@ -170,83 +249,151 @@ export default function DevicesPage() {
           </Card>
         )}
 
-        {/* Filters */}
-        <div className="flex flex-wrap gap-3 mb-6">
-          <div className="relative">
-            <Search className="absolute left-3 top-1/2 -translate-y-1/2 w-4 h-4 text-slate-500" />
-            <input
-              type="text"
-              placeholder="Search devices..."
-              value={searchQuery}
-              onChange={(e) => setSearchQuery(e.target.value)}
-              className="pl-9 pr-4 py-2 bg-slate-800 border border-slate-700 rounded-lg text-sm focus:outline-none focus:border-blue-500"
-            />
-          </div>
-          <select
-            value={filterType}
-            onChange={(e) => setFilterType(e.target.value)}
-            className="px-4 py-2 bg-slate-800 border border-slate-700 rounded-lg text-sm focus:outline-none focus:border-blue-500"
-          >
-            <option value="">All Types</option>
-            {deviceTypes.map((type) => (
-              <option key={type} value={type}>
-                {type.replace('_', ' ')}
-              </option>
-            ))}
-          </select>
-          <select
-            value={filterStatus}
-            onChange={(e) => setFilterStatus(e.target.value)}
-            className="px-4 py-2 bg-slate-800 border border-slate-700 rounded-lg text-sm focus:outline-none focus:border-blue-500"
-          >
-            <option value="">All Status</option>
-            <option value="online">Online</option>
-            <option value="offline">Offline</option>
-            <option value="error">Error</option>
-            <option value="maintenance">Maintenance</option>
-          </select>
+        {/* Tabs */}
+        <div className="flex items-center gap-1 mb-6 border-b border-slate-700">
+          {tabs.map(tab => (
+            <button
+              key={tab.key}
+              onClick={() => setActiveTab(tab.key)}
+              className={`px-4 py-2.5 text-sm font-medium border-b-2 transition-colors ${
+                activeTab === tab.key
+                  ? 'border-blue-500 text-blue-400'
+                  : 'border-transparent text-slate-400 hover:text-slate-300'
+              }`}
+            >
+              {tab.label}
+              {tab.count !== undefined && tab.count > 0 && (
+                <span className={`ml-2 px-1.5 py-0.5 rounded-full text-xs ${
+                  tab.key === 'pending' && tab.count > 0
+                    ? 'bg-amber-500/20 text-amber-400'
+                    : 'bg-slate-700 text-slate-400'
+                }`}>
+                  {tab.count}
+                </span>
+              )}
+            </button>
+          ))}
         </div>
 
-        {/* Device grid */}
-        {loading && (
-          <div className="flex items-center justify-center py-12">
-            <div className="animate-spin w-8 h-8 border-4 border-blue-500 border-t-transparent rounded-full" />
-          </div>
+        {/* Active Devices Tab */}
+        {activeTab === 'active' && (
+          <>
+            {/* Filters */}
+            <div className="flex flex-wrap gap-3 mb-6">
+              <div className="relative">
+                <Search className="absolute left-3 top-1/2 -translate-y-1/2 w-4 h-4 text-slate-500" />
+                <input
+                  type="text"
+                  placeholder="Search devices..."
+                  value={searchQuery}
+                  onChange={(e) => setSearchQuery(e.target.value)}
+                  className="pl-9 pr-4 py-2 bg-slate-800 border border-slate-700 rounded-lg text-sm focus:outline-none focus:border-blue-500"
+                />
+              </div>
+              <select
+                value={filterType}
+                onChange={(e) => setFilterType(e.target.value)}
+                className="px-4 py-2 bg-slate-800 border border-slate-700 rounded-lg text-sm focus:outline-none focus:border-blue-500"
+              >
+                <option value="">All Types</option>
+                {deviceTypes.map((type) => (
+                  <option key={type} value={type}>
+                    {type.replace('_', ' ')}
+                  </option>
+                ))}
+              </select>
+              <select
+                value={filterStatus}
+                onChange={(e) => setFilterStatus(e.target.value)}
+                className="px-4 py-2 bg-slate-800 border border-slate-700 rounded-lg text-sm focus:outline-none focus:border-blue-500"
+              >
+                <option value="">All Status</option>
+                <option value="online">Online</option>
+                <option value="offline">Offline</option>
+                <option value="error">Error</option>
+                <option value="maintenance">Maintenance</option>
+              </select>
+            </div>
+
+            {loading && (
+              <div className="flex items-center justify-center py-12">
+                <div className="animate-spin w-8 h-8 border-4 border-blue-500 border-t-transparent rounded-full" />
+              </div>
+            )}
+
+            {error && (
+              <div className="p-4 bg-red-900/20 border border-red-500 rounded-lg">
+                <p className="text-red-400">Error: {error}</p>
+                <button onClick={refresh} className="mt-2 text-sm text-red-300 underline">
+                  Retry
+                </button>
+              </div>
+            )}
+
+            {!loading && !error && filteredDevices.length === 0 && (
+              activeDevices.length === 0 ? (
+                <EmptyState
+                  icon={Monitor}
+                  title="No devices registered"
+                  description="Devices connect to Maestra via MQTT, WebSocket, or OSC. Register your first device, or enable auto-discovery to detect devices on your network."
+                  action={{ label: 'Register a Device', onClick: () => setShowRegisterForm(true) }}
+                  secondaryAction={{ label: 'Read the Device Guide', href: 'http://localhost:8000/guides/device-registration/' }}
+                />
+              ) : (
+                <p className="text-slate-400 text-center py-12">
+                  No devices match your filters.
+                </p>
+              )
+            )}
+
+            {!loading && filteredDevices.length > 0 && (
+              <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-4">
+                {filteredDevices.map((device) => (
+                  <DeviceCard key={device.id} device={device} onDelete={handleDelete} />
+                ))}
+              </div>
+            )}
+          </>
         )}
 
-        {error && (
-          <div className="p-4 bg-red-900/20 border border-red-500 rounded-lg">
-            <p className="text-red-400">Error: {error}</p>
-            <button onClick={refresh} className="mt-2 text-sm text-red-300 underline">
-              Retry
-            </button>
-          </div>
+        {/* Pending Devices Tab */}
+        {activeTab === 'pending' && (
+          <>
+            {pendingDevices.length === 0 ? (
+              <div className="text-center py-12 text-slate-500">
+                <p className="text-lg mb-2">No pending devices</p>
+                <p className="text-sm">Devices discovered via mDNS on your network will appear here for approval.</p>
+              </div>
+            ) : (
+              <div className="space-y-4">
+                {pendingDevices.map(device => (
+                  <PendingDeviceCard
+                    key={device.id}
+                    device={device}
+                    onApprove={setApproveDevice}
+                    onReject={handleReject}
+                    onBlock={handleBlock}
+                  />
+                ))}
+              </div>
+            )}
+          </>
         )}
 
-        {!loading && !error && filteredDevices.length === 0 && (
-          devices.length === 0 ? (
-            <EmptyState
-              icon={Monitor}
-              title="No devices registered"
-              description="Devices connect to Maestra via MQTT, WebSocket, or OSC. Register your first device or start with Demo Mode to explore with sample data."
-              action={{ label: 'Register a Device', onClick: () => setShowRegisterForm(true) }}
-              secondaryAction={{ label: 'Read the Device Guide', href: 'http://localhost:8000/guides/device-registration/' }}
-            />
-          ) : (
-            <p className="text-slate-400 text-center py-12">
-              No devices match your filters.
-            </p>
-          )
-        )}
-
-        {!loading && filteredDevices.length > 0 && (
-          <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-4">
-            {filteredDevices.map((device) => (
-              <DeviceCard key={device.id} device={device} onDelete={handleDelete} />
-            ))}
-          </div>
+        {/* Blocked Devices Tab */}
+        {activeTab === 'blocked' && (
+          <BlockedDevicesList devices={blockedDevices} onUnblock={handleUnblock} />
         )}
       </div>
+
+      {/* Approve Device Modal */}
+      {approveDevice && (
+        <ApproveDeviceModal
+          device={approveDevice}
+          onConfirm={handleApproveConfirm}
+          onCancel={() => setApproveDevice(null)}
+        />
+      )}
     </div>
   )
 }

--- a/services/dashboard/src/components/ApproveDeviceModal.tsx
+++ b/services/dashboard/src/components/ApproveDeviceModal.tsx
@@ -1,0 +1,177 @@
+'use client'
+
+import { useState, useEffect } from 'react'
+import type { Device, Entity, DeviceApproval } from '@/lib/types'
+import { entitiesApi } from '@/lib/api'
+import { X, Plus, Trash2 } from 'lucide-react'
+
+interface ApproveDeviceModalProps {
+  device: Device
+  onConfirm: (device: Device, approval: DeviceApproval) => void
+  onCancel: () => void
+}
+
+export function ApproveDeviceModal({ device, onConfirm, onCancel }: ApproveDeviceModalProps) {
+  const [name, setName] = useState(device.name)
+  const [entityId, setEntityId] = useState('')
+  const [envVars, setEnvVars] = useState<{ key: string; value: string }[]>([])
+  const [entities, setEntities] = useState<Entity[]>([])
+
+  useEffect(() => {
+    entitiesApi.list().then(setEntities).catch(() => {})
+  }, [])
+
+  const addEnvVar = () => {
+    setEnvVars([...envVars, { key: '', value: '' }])
+  }
+
+  const removeEnvVar = (index: number) => {
+    setEnvVars(envVars.filter((_, i) => i !== index))
+  }
+
+  const updateEnvVar = (index: number, field: 'key' | 'value', val: string) => {
+    const updated = [...envVars]
+    updated[index][field] = val
+    setEnvVars(updated)
+  }
+
+  const handleSubmit = () => {
+    const approval: DeviceApproval = {}
+    if (name !== device.name) approval.name = name
+    if (entityId) approval.entity_id = entityId
+    const validEnvVars = envVars.filter(e => e.key.trim())
+    if (validEnvVars.length > 0) {
+      approval.env_vars = Object.fromEntries(validEnvVars.map(e => [e.key, e.value]))
+    }
+    onConfirm(device, approval)
+  }
+
+  return (
+    <div className="fixed inset-0 bg-black/60 flex items-center justify-center z-50">
+      <div className="bg-slate-800 rounded-xl border border-slate-700 p-6 w-full max-w-lg mx-4 max-h-[90vh] overflow-y-auto">
+        <div className="flex items-center justify-between mb-6">
+          <h2 className="text-xl font-semibold">Approve Device</h2>
+          <button onClick={onCancel} className="text-slate-400 hover:text-white p-1">
+            <X className="w-5 h-5" />
+          </button>
+        </div>
+
+        <div className="space-y-5">
+          {/* Device Info */}
+          <div className="bg-slate-900/50 rounded-lg p-4 text-sm">
+            <div className="grid grid-cols-2 gap-3">
+              <div>
+                <span className="text-slate-500">Hardware ID:</span>
+                <p className="text-slate-300 font-mono text-xs mt-0.5">{device.hardware_id}</p>
+              </div>
+              <div>
+                <span className="text-slate-500">Type:</span>
+                <p className="text-slate-300 mt-0.5">{device.device_type.replace('_', ' ')}</p>
+              </div>
+              {device.ip_address && (
+                <div>
+                  <span className="text-slate-500">IP Address:</span>
+                  <p className="text-slate-300 font-mono text-xs mt-0.5">{device.ip_address}</p>
+                </div>
+              )}
+            </div>
+          </div>
+
+          {/* Device Name */}
+          <div>
+            <label className="block text-sm font-medium text-slate-300 mb-1.5">Device Name</label>
+            <input
+              type="text"
+              value={name}
+              onChange={e => setName(e.target.value)}
+              className="w-full bg-slate-900 border border-slate-700 rounded-lg px-3 py-2 text-sm text-white focus:outline-none focus:border-blue-500"
+              placeholder="Device name"
+            />
+          </div>
+
+          {/* Entity Binding */}
+          <div>
+            <label className="block text-sm font-medium text-slate-300 mb-1.5">
+              Bind to Entity <span className="text-slate-500">(optional)</span>
+            </label>
+            <select
+              value={entityId}
+              onChange={e => setEntityId(e.target.value)}
+              className="w-full bg-slate-900 border border-slate-700 rounded-lg px-3 py-2 text-sm text-white focus:outline-none focus:border-blue-500"
+            >
+              <option value="">None</option>
+              {entities.map(entity => (
+                <option key={entity.id} value={entity.id}>
+                  {entity.path ? `${entity.path} (${entity.name})` : entity.name}
+                </option>
+              ))}
+            </select>
+          </div>
+
+          {/* Environment Variables */}
+          <div>
+            <div className="flex items-center justify-between mb-1.5">
+              <label className="text-sm font-medium text-slate-300">
+                Environment Variables <span className="text-slate-500">(optional)</span>
+              </label>
+              <button
+                onClick={addEnvVar}
+                className="flex items-center gap-1 text-xs text-blue-400 hover:text-blue-300"
+              >
+                <Plus className="w-3 h-3" />
+                Add
+              </button>
+            </div>
+            {envVars.length > 0 ? (
+              <div className="space-y-2">
+                {envVars.map((env, i) => (
+                  <div key={i} className="flex items-center gap-2">
+                    <input
+                      type="text"
+                      value={env.key}
+                      onChange={e => updateEnvVar(i, 'key', e.target.value)}
+                      placeholder="KEY"
+                      className="flex-1 bg-slate-900 border border-slate-700 rounded-lg px-3 py-1.5 text-xs font-mono text-white focus:outline-none focus:border-blue-500"
+                    />
+                    <span className="text-slate-500">=</span>
+                    <input
+                      type="text"
+                      value={env.value}
+                      onChange={e => updateEnvVar(i, 'value', e.target.value)}
+                      placeholder="value"
+                      className="flex-1 bg-slate-900 border border-slate-700 rounded-lg px-3 py-1.5 text-xs font-mono text-white focus:outline-none focus:border-blue-500"
+                    />
+                    <button
+                      onClick={() => removeEnvVar(i)}
+                      className="text-red-400 hover:text-red-300 p-1"
+                    >
+                      <Trash2 className="w-3.5 h-3.5" />
+                    </button>
+                  </div>
+                ))}
+              </div>
+            ) : (
+              <p className="text-xs text-slate-500">No environment variables configured.</p>
+            )}
+          </div>
+        </div>
+
+        {/* Actions */}
+        <div className="flex items-center justify-end gap-3 mt-6 pt-4 border-t border-slate-700">
+          <button
+            onClick={onCancel}
+            className="px-4 py-2 rounded-lg bg-slate-700 hover:bg-slate-600 text-sm font-medium transition-colors"
+          >
+            Cancel
+          </button>
+          <button
+            onClick={handleSubmit}
+            className="px-4 py-2 rounded-lg bg-green-600 hover:bg-green-500 text-white text-sm font-medium transition-colors"
+          >
+            Approve & Configure
+          </button>
+        </div>
+      </div>
+    </div>
+  )
+}

--- a/services/dashboard/src/components/BlockedDevicesList.tsx
+++ b/services/dashboard/src/components/BlockedDevicesList.tsx
@@ -1,0 +1,45 @@
+import type { BlockedDevice } from '@/lib/types'
+import { Card } from './Card'
+import { Unlock } from 'lucide-react'
+
+interface BlockedDevicesListProps {
+  devices: BlockedDevice[]
+  onUnblock: (hardwareId: string) => void
+}
+
+export function BlockedDevicesList({ devices, onUnblock }: BlockedDevicesListProps) {
+  if (devices.length === 0) {
+    return (
+      <div className="text-center py-12 text-slate-500">
+        <p>No blocked devices.</p>
+      </div>
+    )
+  }
+
+  return (
+    <div className="space-y-3">
+      {devices.map(device => (
+        <Card key={device.id} className="hover:border-slate-600 transition-colors">
+          <div className="flex items-center justify-between">
+            <div className="flex-1">
+              <p className="font-mono text-sm text-slate-300">{device.hardware_id}</p>
+              {device.reason && (
+                <p className="text-xs text-slate-500 mt-1">Reason: {device.reason}</p>
+              )}
+              <p className="text-xs text-slate-500 mt-1">
+                Blocked: {new Date(device.blocked_at).toLocaleString()}
+              </p>
+            </div>
+            <button
+              onClick={() => onUnblock(device.hardware_id)}
+              className="flex items-center gap-1.5 px-3 py-1.5 rounded-lg bg-slate-700 hover:bg-slate-600 text-slate-300 text-sm font-medium transition-colors"
+            >
+              <Unlock className="w-3.5 h-3.5" />
+              Unblock
+            </button>
+          </div>
+        </Card>
+      ))}
+    </div>
+  )
+}

--- a/services/dashboard/src/components/PendingDeviceCard.tsx
+++ b/services/dashboard/src/components/PendingDeviceCard.tsx
@@ -1,0 +1,82 @@
+import type { Device } from '@/lib/types'
+import { StatusBadge } from './StatusBadge'
+import { Card } from './Card'
+import { DEVICE_TYPE_ICONS, DEFAULT_DEVICE_ICON } from './icons'
+import { Check, X, Ban } from 'lucide-react'
+
+interface PendingDeviceCardProps {
+  device: Device
+  onApprove: (device: Device) => void
+  onReject: (device: Device) => void
+  onBlock: (device: Device) => void
+}
+
+export function PendingDeviceCard({ device, onApprove, onReject, onBlock }: PendingDeviceCardProps) {
+  const Icon = DEVICE_TYPE_ICONS[device.device_type] || DEFAULT_DEVICE_ICON
+  const discoveredAt = device.last_seen
+    ? new Date(device.last_seen).toLocaleString()
+    : 'Unknown'
+
+  return (
+    <Card className="border-amber-500/30 hover:border-amber-500/50 transition-colors">
+      <div className="flex items-start justify-between">
+        <div className="flex items-start gap-4 flex-1">
+          <div className="w-10 h-10 rounded-lg bg-amber-900/30 flex items-center justify-center shrink-0">
+            <Icon className="w-5 h-5 text-amber-400" />
+          </div>
+          <div className="flex-1">
+            <h3 className="font-semibold text-lg mb-1">{device.name}</h3>
+            <p className="text-sm text-slate-400 mb-2">{device.device_type.replace('_', ' ')}</p>
+            <StatusBadge status="pending" />
+          </div>
+        </div>
+        <div className="flex items-center gap-2">
+          <button
+            onClick={() => onApprove(device)}
+            className="flex items-center gap-1.5 px-3 py-1.5 rounded-lg bg-green-600 hover:bg-green-500 text-white text-sm font-medium transition-colors"
+          >
+            <Check className="w-3.5 h-3.5" />
+            Approve
+          </button>
+          <button
+            onClick={() => onReject(device)}
+            className="flex items-center gap-1.5 px-3 py-1.5 rounded-lg bg-slate-700 hover:bg-slate-600 text-slate-300 text-sm font-medium transition-colors"
+          >
+            <X className="w-3.5 h-3.5" />
+            Reject
+          </button>
+          <button
+            onClick={() => onBlock(device)}
+            className="flex items-center gap-1.5 px-3 py-1.5 rounded-lg bg-red-900/50 hover:bg-red-800/50 text-red-400 text-sm font-medium transition-colors"
+          >
+            <Ban className="w-3.5 h-3.5" />
+            Block
+          </button>
+        </div>
+      </div>
+
+      <div className="mt-4 pt-4 border-t border-slate-700 grid grid-cols-3 gap-4 text-sm">
+        <div>
+          <span className="text-slate-500">Hardware ID:</span>
+          <p className="text-slate-300 font-mono text-xs mt-1">{device.hardware_id}</p>
+        </div>
+        <div>
+          <span className="text-slate-500">Discovered:</span>
+          <p className="text-slate-300 text-xs mt-1">{discoveredAt}</p>
+        </div>
+        {device.ip_address && (
+          <div>
+            <span className="text-slate-500">IP Address:</span>
+            <p className="text-slate-300 font-mono text-xs mt-1">{device.ip_address}</p>
+          </div>
+        )}
+        {device.firmware_version && (
+          <div>
+            <span className="text-slate-500">Firmware:</span>
+            <p className="text-slate-300 text-xs mt-1">{device.firmware_version}</p>
+          </div>
+        )}
+      </div>
+    </Card>
+  )
+}

--- a/services/dashboard/src/components/StatusBadge.tsx
+++ b/services/dashboard/src/components/StatusBadge.tsx
@@ -1,5 +1,5 @@
 interface StatusBadgeProps {
-  status: 'online' | 'offline' | 'error' | 'maintenance' | 'checking' | 'healthy' | 'unhealthy'
+  status: 'online' | 'offline' | 'error' | 'maintenance' | 'checking' | 'healthy' | 'unhealthy' | 'pending'
   showDot?: boolean
   className?: string
 }
@@ -12,6 +12,7 @@ const statusConfig = {
   unhealthy: { color: 'bg-red-500', text: 'Unhealthy', textColor: 'text-red-400' },
   maintenance: { color: 'bg-yellow-500', text: 'Maintenance', textColor: 'text-yellow-400' },
   checking: { color: 'bg-yellow-500 animate-pulse', text: 'Checking', textColor: 'text-yellow-400' },
+  pending: { color: 'bg-amber-500 animate-pulse', text: 'Pending Approval', textColor: 'text-amber-400' },
 }
 
 export function StatusBadge({ status, showDot = true, className = '' }: StatusBadgeProps) {

--- a/services/dashboard/src/hooks/useDiscovery.ts
+++ b/services/dashboard/src/hooks/useDiscovery.ts
@@ -1,0 +1,58 @@
+// Custom hook for device discovery management
+
+import { useEffect, useState, useCallback } from 'react'
+import { discoveryApi } from '@/lib/api'
+import type { Device, BlockedDevice } from '@/lib/types'
+
+export function usePendingDevices(autoRefresh = true, interval = 5000) {
+  const [devices, setDevices] = useState<Device[]>([])
+  const [loading, setLoading] = useState(true)
+  const [error, setError] = useState<string | null>(null)
+
+  const fetchPending = useCallback(async () => {
+    try {
+      setError(null)
+      const data = await discoveryApi.listPending()
+      setDevices(data)
+    } catch (err) {
+      setError(err instanceof Error ? err.message : 'Failed to fetch pending devices')
+    } finally {
+      setLoading(false)
+    }
+  }, [])
+
+  useEffect(() => {
+    fetchPending()
+
+    if (autoRefresh) {
+      const timer = setInterval(fetchPending, interval)
+      return () => clearInterval(timer)
+    }
+  }, [autoRefresh, interval, fetchPending])
+
+  return { devices, loading, error, refresh: fetchPending }
+}
+
+export function useBlockedDevices() {
+  const [devices, setDevices] = useState<BlockedDevice[]>([])
+  const [loading, setLoading] = useState(true)
+  const [error, setError] = useState<string | null>(null)
+
+  const fetchBlocked = useCallback(async () => {
+    try {
+      setError(null)
+      const data = await discoveryApi.listBlocked()
+      setDevices(data)
+    } catch (err) {
+      setError(err instanceof Error ? err.message : 'Failed to fetch blocked devices')
+    } finally {
+      setLoading(false)
+    }
+  }, [])
+
+  useEffect(() => {
+    fetchBlocked()
+  }, [fetchBlocked])
+
+  return { devices, loading, error, refresh: fetchBlocked }
+}

--- a/services/dashboard/src/lib/api.ts
+++ b/services/dashboard/src/lib/api.ts
@@ -8,6 +8,7 @@ import {
   RouteData, RouteCreate, RoutePreset, RoutePresetCreate, RoutePresetUpdate,
   RoutePresetDetail, RoutingState,
   StreamInfo, StreamSession, StreamTypeInfo, StreamRegistryState,
+  BlockedDevice, DeviceProvision, DeviceApproval,
 } from './types'
 
 const API_URL = process.env.NEXT_PUBLIC_API_URL || 'http://localhost:8080'
@@ -241,6 +242,43 @@ export const devicesApi = {
     }),
 }
 
+// Discovery API
+export const discoveryApi = {
+  listPending: () => fetchApi<Device[]>('/devices/pending'),
+
+  approve: (id: string, data?: DeviceApproval) =>
+    fetchApi<Device>(`/devices/${id}/approve`, {
+      method: 'POST',
+      body: JSON.stringify(data || {}),
+    }),
+
+  reject: (id: string) =>
+    fetchApi<{ status: string }>(`/devices/${id}/reject`, {
+      method: 'POST',
+    }),
+
+  block: (id: string, reason?: string) =>
+    fetchApi<{ status: string }>(`/devices/${id}/block`, {
+      method: 'POST',
+      body: JSON.stringify({ reason }),
+    }),
+
+  listBlocked: () => fetchApi<BlockedDevice[]>('/devices/blocked'),
+
+  unblock: (hardwareId: string) =>
+    fetchApi<{ status: string }>(`/devices/blocked/${hardwareId}`, {
+      method: 'DELETE',
+    }),
+
+  getProvision: (id: string) => fetchApi<DeviceProvision>(`/devices/${id}/provision`),
+
+  updateProvision: (id: string, data: Partial<DeviceApproval>) =>
+    fetchApi<DeviceProvision>(`/devices/${id}/provision`, {
+      method: 'PUT',
+      body: JSON.stringify(data),
+    }),
+}
+
 // Routing API
 export const routingApi = {
   // Full state (single fetch for frontend)
@@ -372,6 +410,14 @@ export const api = {
   createEntity: entitiesApi.create,
   updateEntity: entitiesApi.update,
   deleteEntity: entitiesApi.delete,
+
+  // Discovery
+  listPendingDevices: discoveryApi.listPending,
+  approveDevice: discoveryApi.approve,
+  rejectDevice: discoveryApi.reject,
+  blockDevice: discoveryApi.block,
+  listBlockedDevices: discoveryApi.listBlocked,
+  unblockDevice: discoveryApi.unblock,
 
   // Health
   health: healthApi.check,

--- a/services/dashboard/src/lib/types.ts
+++ b/services/dashboard/src/lib/types.ts
@@ -158,10 +158,40 @@ export interface Device {
   ip_address?: string
   location?: Record<string, unknown>
   metadata?: Record<string, unknown>
-  status: 'online' | 'offline' | 'error' | 'maintenance'
+  status: 'online' | 'offline' | 'error' | 'maintenance' | 'pending'
   last_seen?: string
   created_at: string
   updated_at: string
+}
+
+// =============================================================================
+// Discovery & Provisioning Types
+// =============================================================================
+
+export interface BlockedDevice {
+  id: string
+  hardware_id: string
+  reason?: string
+  blocked_at: string
+}
+
+export interface DeviceProvision {
+  device_id: string
+  provision_status: 'pending' | 'approved' | 'provisioned'
+  api_url: string
+  nats_url: string
+  mqtt_broker: string
+  mqtt_port: number
+  ws_url?: string
+  entity_id?: string
+  env_vars: Record<string, string>
+}
+
+export interface DeviceApproval {
+  name?: string
+  entity_id?: string
+  env_vars?: Record<string, string>
+  device_type?: string
 }
 
 // =============================================================================

--- a/services/discovery-service/Dockerfile
+++ b/services/discovery-service/Dockerfile
@@ -1,0 +1,13 @@
+FROM python:3.11-slim
+
+WORKDIR /app
+
+# Copy requirements and install dependencies
+COPY requirements.txt .
+RUN pip install --no-cache-dir -r requirements.txt
+
+# Copy application code
+COPY . .
+
+# Run the discovery service
+CMD ["python", "discovery.py"]

--- a/services/discovery-service/discovery.py
+++ b/services/discovery-service/discovery.py
@@ -1,0 +1,260 @@
+"""
+Maestra Discovery Service
+Advertises Maestra server via mDNS/DNS-SD and listens for device advertisements.
+
+Uses zeroconf to:
+1. Register _maestra._tcp.local. so devices can find the server
+2. Browse _maestra-device._tcp.local. to detect new devices on the network
+3. Report discovered devices to Fleet Manager for approval
+"""
+
+import asyncio
+import json
+import os
+import signal
+import socket
+import logging
+from datetime import datetime
+
+import httpx
+from zeroconf import Zeroconf, ServiceBrowser, ServiceInfo, ServiceStateChange
+from zeroconf.asyncio import AsyncZeroconf, AsyncServiceBrowser, AsyncServiceInfo
+
+logging.basicConfig(
+    level=logging.INFO,
+    format="%(asctime)s [%(levelname)s] %(message)s",
+)
+log = logging.getLogger("maestra-discovery")
+
+# Configuration
+FLEET_MANAGER_URL = os.getenv("FLEET_MANAGER_URL", "http://localhost:8080")
+HOST_IP = os.getenv("HOST_IP", "10.0.0.199")
+NATS_URL = os.getenv("NATS_URL", f"nats://{HOST_IP}:4222")
+MQTT_BROKER = os.getenv("MQTT_BROKER", HOST_IP)
+MQTT_PORT = int(os.getenv("MQTT_PORT", "1883"))
+WS_URL = os.getenv("WS_URL", f"ws://{HOST_IP}:8765")
+API_URL = os.getenv("API_URL", f"http://{HOST_IP}:8080")
+SERVICE_VERSION = os.getenv("MAESTRA_VERSION", "0.2.0")
+
+# mDNS service types
+SERVER_SERVICE_TYPE = "_maestra._tcp.local."
+DEVICE_SERVICE_TYPE = "_maestra-device._tcp.local."
+
+# Track known devices to avoid re-reporting
+known_devices: set[str] = set()
+blocked_devices: set[str] = set()
+
+
+class DeviceListener:
+    """Handles mDNS service discovery events for Maestra devices"""
+
+    def __init__(self, http_client: httpx.AsyncClient, loop: asyncio.AbstractEventLoop):
+        self.http_client = http_client
+        self.loop = loop
+
+    def update_service(self, zc: Zeroconf, type_: str, name: str) -> None:
+        """Called when a service is updated"""
+        pass
+
+    def remove_service(self, zc: Zeroconf, type_: str, name: str) -> None:
+        """Called when a service is removed"""
+        log.info(f"Device service removed: {name}")
+        # Remove from known set so it can be re-discovered
+        known_devices.discard(name)
+
+    def add_service(self, zc: Zeroconf, type_: str, name: str) -> None:
+        """Called when a new device service is discovered"""
+        if name in known_devices:
+            return
+
+        log.info(f"New device service discovered: {name}")
+        asyncio.run_coroutine_threadsafe(
+            self._handle_new_device(zc, type_, name),
+            self.loop,
+        )
+
+    async def _handle_new_device(self, zc: Zeroconf, type_: str, name: str):
+        """Process a newly discovered device"""
+        try:
+            info = ServiceInfo(type_, name)
+            if not info.request(zc, 3000):
+                log.warning(f"Could not resolve service info for {name}")
+                return
+
+            # Extract TXT record properties
+            properties = {}
+            if info.properties:
+                for key, value in info.properties.items():
+                    k = key.decode("utf-8") if isinstance(key, bytes) else key
+                    v = value.decode("utf-8") if isinstance(value, bytes) else str(value)
+                    properties[k] = v
+
+            hardware_id = properties.get("hardware_id", "")
+            if not hardware_id:
+                log.warning(f"Device {name} has no hardware_id in TXT records, skipping")
+                return
+
+            if hardware_id in blocked_devices:
+                log.info(f"Skipping blocked device: {hardware_id}")
+                return
+
+            # Get device IP
+            ip_address = None
+            if info.addresses:
+                ip_address = socket.inet_ntoa(info.addresses[0])
+
+            device_data = {
+                "name": properties.get("name", name.split(".")[0]),
+                "device_type": properties.get("device_type", "unknown"),
+                "hardware_id": hardware_id,
+                "firmware_version": properties.get("firmware_version"),
+                "ip_address": ip_address,
+                "metadata": {
+                    "mdns_name": name,
+                    "discovered_via": "zeroconf",
+                    "discovered_at": datetime.utcnow().isoformat() + "Z",
+                    **{k: v for k, v in properties.items()
+                       if k not in ("hardware_id", "name", "device_type", "firmware_version")},
+                },
+            }
+
+            log.info(f"Reporting device to Fleet Manager: {hardware_id} ({device_data['name']})")
+            response = await self.http_client.post(
+                f"{FLEET_MANAGER_URL}/devices/discover",
+                json=device_data,
+                timeout=10.0,
+            )
+
+            if response.status_code == 200:
+                known_devices.add(name)
+                log.info(f"Device registered as pending: {hardware_id}")
+            elif response.status_code == 403:
+                blocked_devices.add(hardware_id)
+                known_devices.add(name)
+                log.info(f"Device is blocked: {hardware_id}")
+            elif response.status_code == 409:
+                known_devices.add(name)
+                log.info(f"Device already registered: {hardware_id}")
+            else:
+                log.error(f"Fleet Manager returned {response.status_code}: {response.text}")
+
+        except Exception as e:
+            log.error(f"Error handling discovered device {name}: {e}")
+
+
+def build_server_service_info() -> ServiceInfo:
+    """Build the mDNS service info for the Maestra server"""
+    # Resolve host IP to bytes
+    try:
+        ip_bytes = socket.inet_aton(HOST_IP)
+    except socket.error:
+        log.warning(f"Invalid HOST_IP '{HOST_IP}', falling back to 0.0.0.0")
+        ip_bytes = socket.inet_aton("0.0.0.0")
+
+    properties = {
+        "api_url": API_URL,
+        "nats_url": NATS_URL,
+        "mqtt_broker": MQTT_BROKER,
+        "mqtt_port": str(MQTT_PORT),
+        "ws_url": WS_URL,
+        "version": SERVICE_VERSION,
+    }
+
+    return ServiceInfo(
+        SERVER_SERVICE_TYPE,
+        f"Maestra.{SERVER_SERVICE_TYPE}",
+        addresses=[ip_bytes],
+        port=8080,
+        properties=properties,
+        server=f"maestra-server.local.",
+    )
+
+
+async def refresh_blocked_list(http_client: httpx.AsyncClient):
+    """Periodically refresh the blocked devices list from Fleet Manager"""
+    while True:
+        try:
+            response = await http_client.get(
+                f"{FLEET_MANAGER_URL}/devices/blocked",
+                timeout=10.0,
+            )
+            if response.status_code == 200:
+                data = response.json()
+                blocked_devices.clear()
+                blocked_devices.update(d["hardware_id"] for d in data)
+                log.debug(f"Refreshed blocked list: {len(blocked_devices)} entries")
+        except Exception as e:
+            log.debug(f"Could not refresh blocked list: {e}")
+
+        await asyncio.sleep(60)  # Refresh every minute
+
+
+async def main():
+    """Main entry point"""
+    log.info("=" * 60)
+    log.info("Maestra Discovery Service starting")
+    log.info(f"  Fleet Manager: {FLEET_MANAGER_URL}")
+    log.info(f"  Host IP: {HOST_IP}")
+    log.info(f"  Server service: {SERVER_SERVICE_TYPE}")
+    log.info(f"  Device service: {DEVICE_SERVICE_TYPE}")
+    log.info("=" * 60)
+
+    # Wait for Fleet Manager to be available
+    http_client = httpx.AsyncClient()
+    for attempt in range(30):
+        try:
+            r = await http_client.get(f"{FLEET_MANAGER_URL}/health", timeout=5.0)
+            if r.status_code == 200:
+                log.info("Fleet Manager is healthy")
+                break
+        except Exception:
+            pass
+        log.info(f"Waiting for Fleet Manager... (attempt {attempt + 1}/30)")
+        await asyncio.sleep(2)
+    else:
+        log.error("Fleet Manager not available after 60 seconds, exiting")
+        return
+
+    loop = asyncio.get_running_loop()
+
+    # Initialize zeroconf
+    zc = Zeroconf()
+
+    # Register the Maestra server service
+    server_info = build_server_service_info()
+    log.info(f"Registering mDNS service: {SERVER_SERVICE_TYPE}")
+    zc.register_service(server_info)
+    log.info(f"Maestra server advertised at {HOST_IP}:8080")
+
+    # Browse for device services
+    listener = DeviceListener(http_client, loop)
+    browser = ServiceBrowser(zc, DEVICE_SERVICE_TYPE, listener)
+    log.info(f"Listening for device advertisements on {DEVICE_SERVICE_TYPE}")
+
+    # Start blocked list refresh task
+    refresh_task = asyncio.create_task(refresh_blocked_list(http_client))
+
+    # Wait for shutdown signal
+    shutdown_event = asyncio.Event()
+
+    def signal_handler():
+        log.info("Shutdown signal received")
+        shutdown_event.set()
+
+    for sig in (signal.SIGINT, signal.SIGTERM):
+        loop.add_signal_handler(sig, signal_handler)
+
+    try:
+        await shutdown_event.wait()
+    finally:
+        log.info("Shutting down...")
+        refresh_task.cancel()
+        browser.cancel()
+        zc.unregister_service(server_info)
+        zc.close()
+        await http_client.aclose()
+        log.info("Discovery service stopped")
+
+
+if __name__ == "__main__":
+    asyncio.run(main())

--- a/services/discovery-service/requirements.txt
+++ b/services/discovery-service/requirements.txt
@@ -1,0 +1,3 @@
+zeroconf==0.131.0
+nats-py==2.6.0
+httpx==0.26.0

--- a/services/fleet-manager/database.py
+++ b/services/fleet-manager/database.py
@@ -110,6 +110,36 @@ class DeviceDB(Base):
 # Routing Models
 # =============================================================================
 
+class BlockedDeviceDB(Base):
+    """Blocked device hardware IDs - rejected on discovery"""
+    __tablename__ = "blocked_devices"
+
+    id = Column(PGUUID(as_uuid=True), primary_key=True, default=uuid4)
+    hardware_id = Column(String(255), unique=True, nullable=False)
+    reason = Column(Text)
+    blocked_at = Column(DateTime, default=datetime.utcnow)
+
+
+class DeviceProvisionDB(Base):
+    """Device provisioning config - pushed to devices after approval"""
+    __tablename__ = "device_provisions"
+
+    id = Column(PGUUID(as_uuid=True), primary_key=True, default=uuid4)
+    device_id = Column(PGUUID(as_uuid=True), ForeignKey("devices.id", ondelete="CASCADE"), unique=True, nullable=False)
+    entity_id = Column(PGUUID(as_uuid=True), ForeignKey("entities.id", ondelete="SET NULL"))
+    env_vars = Column(JSONB, default={})
+    connection_config = Column(JSONB, default={})
+    provision_status = Column(String(50), default='pending')
+    approved_at = Column(DateTime)
+    provisioned_at = Column(DateTime)
+    created_at = Column(DateTime, default=datetime.utcnow)
+    updated_at = Column(DateTime, default=datetime.utcnow, onupdate=datetime.utcnow)
+
+
+# =============================================================================
+# Routing Models
+# =============================================================================
+
 class RoutingDeviceDB(Base):
     """Routing device - signal chain equipment for visual patching"""
     __tablename__ = "routing_devices"

--- a/services/fleet-manager/discovery_router.py
+++ b/services/fleet-manager/discovery_router.py
@@ -1,0 +1,402 @@
+"""
+Discovery API Router
+Device discovery, approval, blocking, and provisioning endpoints
+"""
+
+from fastapi import APIRouter, HTTPException, Depends
+from sqlalchemy.ext.asyncio import AsyncSession
+from sqlalchemy import select, delete
+from typing import List
+from uuid import UUID
+from datetime import datetime
+import json
+import os
+
+from database import get_db, DeviceDB, BlockedDeviceDB, DeviceProvisionDB
+from models import (
+    Device, DeviceStatus,
+    DeviceDiscover, DeviceApproval, DeviceProvisionResponse,
+    BlockedDeviceResponse, BlockDeviceRequest,
+)
+from state_manager import state_manager
+
+router = APIRouter(tags=["discovery"])
+
+
+# =============================================================================
+# Helpers
+# =============================================================================
+
+def device_db_to_response(db_device: DeviceDB) -> Device:
+    """Convert database model to response model"""
+    return Device(
+        id=db_device.id,
+        name=db_device.name,
+        device_type=db_device.device_type,
+        hardware_id=db_device.hardware_id,
+        firmware_version=db_device.firmware_version,
+        ip_address=db_device.ip_address,
+        location=db_device.location,
+        metadata=db_device.device_metadata,
+        status=db_device.status,
+        last_seen=db_device.last_seen,
+        created_at=db_device.created_at or datetime.utcnow(),
+        updated_at=db_device.updated_at or datetime.utcnow(),
+    )
+
+
+async def _broadcast_discovery_event(event_type: str, data: dict):
+    """Broadcast discovery events to NATS and MQTT"""
+    event = {
+        "type": f"device_{event_type}",
+        "timestamp": datetime.utcnow().isoformat() + "Z",
+        **data,
+    }
+    payload = json.dumps(event).encode()
+    subject = f"maestra.device.{event_type}"
+
+    # Publish to NATS
+    if state_manager.nc and not state_manager.nc.is_closed:
+        try:
+            await state_manager.nc.publish(subject, payload)
+        except Exception:
+            pass
+
+    # Publish to MQTT
+    if state_manager.mqtt_client and state_manager.mqtt_client.is_connected():
+        try:
+            mqtt_topic = subject.replace(".", "/")
+            state_manager.mqtt_client.publish(mqtt_topic, payload)
+        except Exception:
+            pass
+
+
+# =============================================================================
+# Device Discovery
+# =============================================================================
+
+@router.post("/devices/discover", response_model=Device)
+async def discover_device(
+    device: DeviceDiscover,
+    db: AsyncSession = Depends(get_db),
+):
+    """
+    Register a discovered device as pending.
+    Called by the discovery service when a new device is found via mDNS.
+    Idempotent: returns existing device if hardware_id already registered.
+    """
+    # Check if hardware_id is blocked
+    blocked = await db.execute(
+        select(BlockedDeviceDB).where(BlockedDeviceDB.hardware_id == device.hardware_id)
+    )
+    if blocked.scalar_one_or_none():
+        raise HTTPException(status_code=403, detail="Device hardware_id is blocked")
+
+    # Check if device already exists
+    existing = await db.execute(
+        select(DeviceDB).where(DeviceDB.hardware_id == device.hardware_id)
+    )
+    existing_device = existing.scalar_one_or_none()
+    if existing_device:
+        # Update IP if it changed
+        if device.ip_address and device.ip_address != existing_device.ip_address:
+            existing_device.ip_address = device.ip_address
+            existing_device.last_seen = datetime.utcnow()
+            await db.commit()
+            await db.refresh(existing_device)
+        return device_db_to_response(existing_device)
+
+    # Create new pending device
+    new_device = DeviceDB(
+        name=device.name,
+        device_type=device.device_type,
+        hardware_id=device.hardware_id,
+        firmware_version=device.firmware_version,
+        ip_address=device.ip_address,
+        device_metadata=device.metadata or {},
+        status=DeviceStatus.PENDING,
+        last_seen=datetime.utcnow(),
+    )
+    db.add(new_device)
+    await db.flush()
+
+    # Create provisioning record
+    provision = DeviceProvisionDB(
+        device_id=new_device.id,
+        provision_status="pending",
+    )
+    db.add(provision)
+    await db.commit()
+    await db.refresh(new_device)
+
+    # Broadcast discovery event
+    await _broadcast_discovery_event("discovered", {
+        "device_id": str(new_device.id),
+        "hardware_id": device.hardware_id,
+        "name": device.name,
+        "device_type": device.device_type,
+        "ip_address": device.ip_address,
+    })
+
+    return device_db_to_response(new_device)
+
+
+# =============================================================================
+# Pending Devices
+# =============================================================================
+
+@router.get("/devices/pending", response_model=List[Device])
+async def list_pending_devices(db: AsyncSession = Depends(get_db)):
+    """List all devices with pending status"""
+    result = await db.execute(
+        select(DeviceDB)
+        .where(DeviceDB.status == DeviceStatus.PENDING)
+        .order_by(DeviceDB.created_at.desc())
+    )
+    return [device_db_to_response(d) for d in result.scalars().all()]
+
+
+# =============================================================================
+# Approval / Rejection / Blocking
+# =============================================================================
+
+@router.post("/devices/{device_id}/approve", response_model=Device)
+async def approve_device(
+    device_id: UUID,
+    approval: DeviceApproval = None,
+    db: AsyncSession = Depends(get_db),
+):
+    """Approve a pending device. Optionally override name, set entity binding, and env vars."""
+    result = await db.execute(
+        select(DeviceDB).where(DeviceDB.id == device_id)
+    )
+    device = result.scalar_one_or_none()
+    if not device:
+        raise HTTPException(status_code=404, detail="Device not found")
+    if device.status != DeviceStatus.PENDING:
+        raise HTTPException(status_code=400, detail=f"Device is not pending (status: {device.status})")
+
+    # Apply overrides
+    if approval:
+        if approval.name:
+            device.name = approval.name
+        if approval.device_type:
+            device.device_type = approval.device_type
+
+    device.status = DeviceStatus.ONLINE
+    device.last_seen = datetime.utcnow()
+
+    # Update provisioning record
+    prov_result = await db.execute(
+        select(DeviceProvisionDB).where(DeviceProvisionDB.device_id == device_id)
+    )
+    provision = prov_result.scalar_one_or_none()
+    if provision:
+        provision.provision_status = "approved"
+        provision.approved_at = datetime.utcnow()
+        # Build connection config from environment
+        provision.connection_config = {
+            "api_url": f"http://{os.getenv('HOST_IP', 'localhost')}:8080",
+            "nats_url": f"nats://{os.getenv('HOST_IP', 'localhost')}:4222",
+            "mqtt_broker": os.getenv('HOST_IP', 'localhost'),
+            "mqtt_port": 1883,
+            "ws_url": f"ws://{os.getenv('HOST_IP', 'localhost')}:8765",
+        }
+        if approval:
+            if approval.entity_id:
+                provision.entity_id = approval.entity_id
+            if approval.env_vars:
+                provision.env_vars = approval.env_vars
+
+    await db.commit()
+    await db.refresh(device)
+
+    # Broadcast approval event
+    await _broadcast_discovery_event("approved", {
+        "device_id": str(device.id),
+        "hardware_id": device.hardware_id,
+        "name": device.name,
+    })
+
+    return device_db_to_response(device)
+
+
+@router.post("/devices/{device_id}/reject")
+async def reject_device(
+    device_id: UUID,
+    db: AsyncSession = Depends(get_db),
+):
+    """Reject and delete a pending device"""
+    result = await db.execute(
+        select(DeviceDB).where(DeviceDB.id == device_id)
+    )
+    device = result.scalar_one_or_none()
+    if not device:
+        raise HTTPException(status_code=404, detail="Device not found")
+    if device.status != DeviceStatus.PENDING:
+        raise HTTPException(status_code=400, detail=f"Device is not pending (status: {device.status})")
+
+    hardware_id = device.hardware_id
+    device_name = device.name
+
+    await db.delete(device)
+    await db.commit()
+
+    await _broadcast_discovery_event("rejected", {
+        "device_id": str(device_id),
+        "hardware_id": hardware_id,
+        "name": device_name,
+    })
+
+    return {"status": "rejected", "device_id": str(device_id)}
+
+
+@router.post("/devices/{device_id}/block")
+async def block_device(
+    device_id: UUID,
+    request: BlockDeviceRequest = None,
+    db: AsyncSession = Depends(get_db),
+):
+    """Block a device's hardware_id and delete the device"""
+    result = await db.execute(
+        select(DeviceDB).where(DeviceDB.id == device_id)
+    )
+    device = result.scalar_one_or_none()
+    if not device:
+        raise HTTPException(status_code=404, detail="Device not found")
+
+    hardware_id = device.hardware_id
+
+    # Add to blocked list
+    blocked = BlockedDeviceDB(
+        hardware_id=hardware_id,
+        reason=request.reason if request else None,
+    )
+    db.add(blocked)
+
+    # Delete the device
+    await db.delete(device)
+    await db.commit()
+
+    await _broadcast_discovery_event("blocked", {
+        "hardware_id": hardware_id,
+        "reason": request.reason if request else None,
+    })
+
+    return {"status": "blocked", "hardware_id": hardware_id}
+
+
+# =============================================================================
+# Blocked Devices
+# =============================================================================
+
+@router.get("/devices/blocked", response_model=List[BlockedDeviceResponse])
+async def list_blocked_devices(db: AsyncSession = Depends(get_db)):
+    """List all blocked hardware IDs"""
+    result = await db.execute(
+        select(BlockedDeviceDB).order_by(BlockedDeviceDB.blocked_at.desc())
+    )
+    return [BlockedDeviceResponse.model_validate(b) for b in result.scalars().all()]
+
+
+@router.delete("/devices/blocked/{hardware_id}")
+async def unblock_device(
+    hardware_id: str,
+    db: AsyncSession = Depends(get_db),
+):
+    """Remove a hardware_id from the blocked list"""
+    result = await db.execute(
+        select(BlockedDeviceDB).where(BlockedDeviceDB.hardware_id == hardware_id)
+    )
+    blocked = result.scalar_one_or_none()
+    if not blocked:
+        raise HTTPException(status_code=404, detail="Hardware ID not found in blocked list")
+
+    await db.delete(blocked)
+    await db.commit()
+
+    return {"status": "unblocked", "hardware_id": hardware_id}
+
+
+# =============================================================================
+# Provisioning
+# =============================================================================
+
+@router.get("/devices/{device_id}/provision", response_model=DeviceProvisionResponse)
+async def get_device_provision(
+    device_id: UUID,
+    db: AsyncSession = Depends(get_db),
+):
+    """
+    Device fetches its provisioning config after approval.
+    Marks provision as 'provisioned' on first successful retrieval.
+    """
+    result = await db.execute(
+        select(DeviceProvisionDB).where(DeviceProvisionDB.device_id == device_id)
+    )
+    provision = result.scalar_one_or_none()
+    if not provision:
+        raise HTTPException(status_code=404, detail="No provisioning record found")
+
+    if provision.provision_status == "pending":
+        raise HTTPException(status_code=403, detail="Device has not been approved yet")
+
+    # Mark as provisioned on first retrieval
+    if provision.provision_status == "approved":
+        provision.provision_status = "provisioned"
+        provision.provisioned_at = datetime.utcnow()
+        await db.commit()
+        await db.refresh(provision)
+
+        await _broadcast_discovery_event("provisioned", {
+            "device_id": str(device_id),
+        })
+
+    conn = provision.connection_config or {}
+    return DeviceProvisionResponse(
+        device_id=provision.device_id,
+        provision_status=provision.provision_status,
+        api_url=conn.get("api_url", f"http://{os.getenv('HOST_IP', 'localhost')}:8080"),
+        nats_url=conn.get("nats_url", f"nats://{os.getenv('HOST_IP', 'localhost')}:4222"),
+        mqtt_broker=conn.get("mqtt_broker", os.getenv('HOST_IP', 'localhost')),
+        mqtt_port=conn.get("mqtt_port", 1883),
+        ws_url=conn.get("ws_url", f"ws://{os.getenv('HOST_IP', 'localhost')}:8765"),
+        entity_id=provision.entity_id,
+        env_vars=provision.env_vars or {},
+    )
+
+
+@router.put("/devices/{device_id}/provision", response_model=DeviceProvisionResponse)
+async def update_device_provision(
+    device_id: UUID,
+    update: DeviceApproval,
+    db: AsyncSession = Depends(get_db),
+):
+    """Admin updates provisioning config (env vars, entity binding)"""
+    result = await db.execute(
+        select(DeviceProvisionDB).where(DeviceProvisionDB.device_id == device_id)
+    )
+    provision = result.scalar_one_or_none()
+    if not provision:
+        raise HTTPException(status_code=404, detail="No provisioning record found")
+
+    if update.entity_id is not None:
+        provision.entity_id = update.entity_id
+    if update.env_vars is not None:
+        provision.env_vars = update.env_vars
+
+    await db.commit()
+    await db.refresh(provision)
+
+    conn = provision.connection_config or {}
+    return DeviceProvisionResponse(
+        device_id=provision.device_id,
+        provision_status=provision.provision_status,
+        api_url=conn.get("api_url", f"http://{os.getenv('HOST_IP', 'localhost')}:8080"),
+        nats_url=conn.get("nats_url", f"nats://{os.getenv('HOST_IP', 'localhost')}:4222"),
+        mqtt_broker=conn.get("mqtt_broker", os.getenv('HOST_IP', 'localhost')),
+        mqtt_port=conn.get("mqtt_port", 1883),
+        ws_url=conn.get("ws_url", f"ws://{os.getenv('HOST_IP', 'localhost')}:8765"),
+        entity_id=provision.entity_id,
+        env_vars=provision.env_vars or {},
+    )

--- a/services/fleet-manager/main.py
+++ b/services/fleet-manager/main.py
@@ -29,6 +29,7 @@ from stream_preview import router as stream_preview_router
 from analytics_router import router as analytics_router
 from cloud_router import router as cloud_router
 from cloud_manager import cloud_manager
+from discovery_router import router as discovery_router
 
 # Initialize FastAPI app
 app = FastAPI(
@@ -53,6 +54,7 @@ app.include_router(stream_router)
 app.include_router(stream_preview_router)
 app.include_router(analytics_router)
 app.include_router(cloud_router)
+app.include_router(discovery_router)
 
 
 # =============================================================================

--- a/services/fleet-manager/models.py
+++ b/services/fleet-manager/models.py
@@ -256,6 +256,7 @@ class DeviceStatus:
     OFFLINE = "offline"
     ERROR = "error"
     MAINTENANCE = "maintenance"
+    PENDING = "pending"
 
 
 class Device(BaseModel):
@@ -311,6 +312,57 @@ class DeviceEvent(BaseModel):
     severity: str = "info"
     message: Optional[str] = None
     data: Optional[Dict[str, Any]] = None
+
+
+# =============================================================================
+# Device Discovery & Provisioning Models
+# =============================================================================
+
+class DeviceDiscover(BaseModel):
+    """Called by discovery service when a new device is found via mDNS"""
+    name: str
+    device_type: str
+    hardware_id: str
+    firmware_version: Optional[str] = None
+    ip_address: Optional[str] = None
+    metadata: Optional[Dict[str, Any]] = None
+
+
+class DeviceApproval(BaseModel):
+    """Admin approves a pending device with optional config"""
+    name: Optional[str] = None
+    entity_id: Optional[UUID] = None
+    env_vars: Optional[Dict[str, Any]] = None
+    device_type: Optional[str] = None
+
+
+class DeviceProvisionResponse(BaseModel):
+    """Provisioning config returned to device after approval"""
+    device_id: UUID
+    provision_status: str
+    api_url: str
+    nats_url: str
+    mqtt_broker: str
+    mqtt_port: int
+    ws_url: Optional[str] = None
+    entity_id: Optional[UUID] = None
+    env_vars: Dict[str, Any] = Field(default_factory=dict)
+
+
+class BlockedDeviceResponse(BaseModel):
+    """Blocked device response"""
+    id: UUID
+    hardware_id: str
+    reason: Optional[str] = None
+    blocked_at: datetime
+
+    class Config:
+        from_attributes = True
+
+
+class BlockDeviceRequest(BaseModel):
+    """Request to block a device"""
+    reason: Optional[str] = None
 
 
 # =============================================================================


### PR DESCRIPTION
## Summary
- **Discovery Service**: New Docker service that advertises Maestra via `_maestra._tcp.local.` mDNS and listens for `_maestra-device._tcp.local.` device advertisements, automatically registering discovered devices as pending
- **Fleet Manager API**: 9 new endpoints for device discovery, approval/reject/block workflows, and provisioning (connection config + env vars + entity binding)
- **Dashboard**: Devices page now has Active/Pending/Blocked tabs with approval modal (name override, entity binding dropdown, key-value env var editor)
- **Python SDK**: `MaestraClient.discover()` classmethod for zero-config connection, plus `advertise_device()` and `wait_for_provisioning()` helpers
- **Database**: New `blocked_devices` and `device_provisions` tables with migration `003_discovery.sql`

## Test plan
- [ ] Run `make migrate` to apply the new migration
- [ ] Start the stack with `make up` and verify discovery-service starts
- [ ] Test discovery API: `curl -X POST localhost:8080/devices/discover -d '{"name":"test","device_type":"esp32","hardware_id":"AA:BB:CC:DD:EE:FF"}' -H 'Content-Type: application/json'`
- [ ] Verify pending device appears: `curl localhost:8080/devices/pending`
- [ ] Test approve/reject/block flows via the dashboard Pending tab
- [ ] Verify the approval modal allows entity binding and env var configuration
- [ ] Test Python SDK: `client = await MaestraClient.discover()` on the same LAN

🤖 Generated with [Claude Code](https://claude.com/claude-code)