### PR TITLE
Feature/deploy sdks

### DIFF
--- a/.github/workflows/publish-arduino.yml
+++ b/.github/workflows/publish-arduino.yml
@@ -1,0 +1,42 @@
+name: Publish Arduino SDK to PlatformIO
+
+on:
+  push:
+    tags:
+      - 'arduino/v*'
+
+jobs:
+  publish:
+    name: Publish to PlatformIO Registry
+    runs-on: ubuntu-latest
+    environment:
+      name: platformio
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.11'
+
+      - name: Install PlatformIO
+        run: pip install platformio
+
+      - name: Extract version from tag
+        id: version
+        run: echo "version=${GITHUB_REF_NAME#arduino/v}" >> "$GITHUB_OUTPUT"
+
+      - name: Verify version matches library.json
+        working-directory: sdks/arduino/MaestraClient
+        run: |
+          LIB_VERSION=$(python -c "import json; print(json.load(open('library.json'))['version'])")
+          if [ "$LIB_VERSION" != "${{ steps.version.outputs.version }}" ]; then
+            echo "::error::Tag version (${{ steps.version.outputs.version }}) does not match library.json version ($LIB_VERSION)"
+            exit 1
+          fi
+
+      - name: Publish to PlatformIO Registry
+        working-directory: sdks/arduino/MaestraClient
+        run: pio pkg publish --no-interactive
+        env:
+          PLATFORMIO_AUTH_TOKEN: ${{ secrets.PLATFORMIO_AUTH_TOKEN }}

--- a/.github/workflows/publish-js.yml
+++ b/.github/workflows/publish-js.yml
@@ -1,0 +1,58 @@
+name: Publish JS/TS SDK to npm
+
+on:
+  push:
+    tags:
+      - 'js/v*'
+
+permissions:
+  contents: read
+  id-token: write  # npm provenance
+
+jobs:
+  publish:
+    name: Build and publish to npm
+    runs-on: ubuntu-latest
+    environment:
+      name: npm
+      url: https://www.npmjs.com/package/@maestra/sdk
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Set up Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          registry-url: https://registry.npmjs.org
+
+      - name: Extract version from tag
+        id: version
+        run: echo "version=${GITHUB_REF_NAME#js/v}" >> "$GITHUB_OUTPUT"
+
+      - name: Verify version matches package.json
+        working-directory: sdks/js
+        run: |
+          PKG_VERSION=$(node -p "require('./package.json').version")
+          if [ "$PKG_VERSION" != "${{ steps.version.outputs.version }}" ]; then
+            echo "::error::Tag version (${{ steps.version.outputs.version }}) does not match package.json version ($PKG_VERSION)"
+            exit 1
+          fi
+
+      - name: Install dependencies
+        working-directory: sdks/js
+        run: npm ci
+
+      - name: Build
+        working-directory: sdks/js
+        run: npm run build
+
+      - name: Run tests
+        working-directory: sdks/js
+        run: npm test -- --run
+        continue-on-error: true  # Don't block publish if no tests exist yet
+
+      - name: Publish to npm
+        working-directory: sdks/js
+        run: npm publish --provenance --access public
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}

--- a/.github/workflows/publish-python.yml
+++ b/.github/workflows/publish-python.yml
@@ -1,0 +1,54 @@
+name: Publish Python SDK to PyPI
+
+on:
+  push:
+    tags:
+      - 'python/v*'
+
+permissions:
+  id-token: write  # Required for OIDC trusted publishing
+
+jobs:
+  publish:
+    name: Build and publish to PyPI
+    runs-on: ubuntu-latest
+    environment:
+      name: pypi
+      url: https://pypi.org/project/maestra/
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.11'
+
+      - name: Install build tools
+        run: pip install build
+
+      - name: Extract version from tag
+        id: version
+        run: echo "version=${GITHUB_REF_NAME#python/v}" >> "$GITHUB_OUTPUT"
+
+      - name: Verify version matches pyproject.toml
+        working-directory: sdks/python
+        run: |
+          TOML_VERSION=$(python -c "
+          import re
+          with open('pyproject.toml') as f:
+              match = re.search(r'^version = \"(.+)\"', f.read(), re.MULTILINE)
+              print(match.group(1))
+          ")
+          if [ "$TOML_VERSION" != "${{ steps.version.outputs.version }}" ]; then
+            echo "::error::Tag version (${{ steps.version.outputs.version }}) does not match pyproject.toml version ($TOML_VERSION)"
+            exit 1
+          fi
+
+      - name: Build package
+        working-directory: sdks/python
+        run: python -m build
+
+      - name: Publish to PyPI
+        uses: pypa/gh-action-pypi-publish@release/v1
+        with:
+          packages-dir: sdks/python/dist/

--- a/.github/workflows/publish-touchdesigner.yml
+++ b/.github/workflows/publish-touchdesigner.yml
@@ -1,0 +1,52 @@
+name: Publish TouchDesigner SDK (GitHub Release)
+
+on:
+  push:
+    tags:
+      - 'touchdesigner/v*'
+
+permissions:
+  contents: write  # Needed to create releases
+
+jobs:
+  publish:
+    name: Package and release TouchDesigner SDK
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Extract version from tag
+        id: version
+        run: echo "version=${GITHUB_REF_NAME#touchdesigner/v}" >> "$GITHUB_OUTPUT"
+
+      - name: Package SDK as zip
+        run: |
+          cd sdks
+          zip -r "../MaestraTouchDesigner-${{ steps.version.outputs.version }}.zip" touchdesigner/
+          cd ..
+          echo "Created MaestraTouchDesigner-${{ steps.version.outputs.version }}.zip"
+          ls -lh "MaestraTouchDesigner-${{ steps.version.outputs.version }}.zip"
+
+      - name: Create GitHub Release
+        uses: softprops/action-gh-release@v2
+        with:
+          name: "TouchDesigner SDK v${{ steps.version.outputs.version }}"
+          body: |
+            ## Maestra TouchDesigner SDK — v${{ steps.version.outputs.version }}
+
+            ### Installation
+            1. Download and extract `MaestraTouchDesigner-${{ steps.version.outputs.version }}.zip`
+            2. In TouchDesigner, create a **Text DAT**
+            3. Set its file path to `build_maestra_tox.py` from the extracted folder
+            4. Right-click the DAT → **Run Script**
+
+            See the [TouchDesigner integration guide](https://maestra.dev/docs/connect/touchdesigner/) for full setup instructions.
+
+            ### Files included
+            - `build_maestra_tox.py` — COMP builder script
+            - `MaestraExt.py` — Extension class with API methods
+            - `MaestraDiscovery.py` — mDNS discovery module
+          files: |
+            MaestraTouchDesigner-${{ steps.version.outputs.version }}.zip
+          draft: false
+          prerelease: ${{ contains(steps.version.outputs.version, '-') }}

--- a/.github/workflows/publish-unity.yml
+++ b/.github/workflows/publish-unity.yml
@@ -1,0 +1,63 @@
+name: Publish Unity SDK (UPM Branch)
+
+on:
+  push:
+    tags:
+      - 'unity/v*'
+
+permissions:
+  contents: write  # Needed to push upm branch
+
+jobs:
+  publish:
+    name: Update UPM branch for OpenUPM
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0  # Full history needed for subtree split
+
+      - name: Extract version from tag
+        id: version
+        run: echo "version=${GITHUB_REF_NAME#unity/v}" >> "$GITHUB_OUTPUT"
+
+      - name: Verify version matches package.json
+        run: |
+          PKG_VERSION=$(node -p "require('./sdks/unity/package.json').version")
+          if [ "$PKG_VERSION" != "${{ steps.version.outputs.version }}" ]; then
+            echo "::error::Tag version (${{ steps.version.outputs.version }}) does not match package.json version ($PKG_VERSION)"
+            exit 1
+          fi
+
+      - name: Split Unity SDK subtree to upm branch
+        run: |
+          git config user.name "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+
+          # Create a subtree split containing only sdks/unity/
+          SPLIT_SHA=$(git subtree split --prefix=sdks/unity/ -b upm-split)
+
+          # Force-update the upm branch
+          git push origin "$SPLIT_SHA":refs/heads/upm --force
+
+          # Create a version tag on the upm branch for OpenUPM
+          git tag "v${{ steps.version.outputs.version }}" "$SPLIT_SHA" -f
+          git push origin "v${{ steps.version.outputs.version }}" --force
+
+          echo "UPM branch updated and tagged v${{ steps.version.outputs.version }}"
+
+      - name: Summary
+        run: |
+          echo "## Unity SDK v${{ steps.version.outputs.version }} Published" >> "$GITHUB_STEP_SUMMARY"
+          echo "" >> "$GITHUB_STEP_SUMMARY"
+          echo "The \`upm\` branch has been updated with the latest Unity SDK." >> "$GITHUB_STEP_SUMMARY"
+          echo "" >> "$GITHUB_STEP_SUMMARY"
+          echo "### Install via Unity Package Manager" >> "$GITHUB_STEP_SUMMARY"
+          echo '```' >> "$GITHUB_STEP_SUMMARY"
+          echo "https://github.com/${{ github.repository }}.git#upm" >> "$GITHUB_STEP_SUMMARY"
+          echo '```' >> "$GITHUB_STEP_SUMMARY"
+          echo "" >> "$GITHUB_STEP_SUMMARY"
+          echo "### Install via OpenUPM" >> "$GITHUB_STEP_SUMMARY"
+          echo '```' >> "$GITHUB_STEP_SUMMARY"
+          echo "openupm add dev.maestra.sdk" >> "$GITHUB_STEP_SUMMARY"
+          echo '```' >> "$GITHUB_STEP_SUMMARY"

--- a/.github/workflows/publish-unreal.yml
+++ b/.github/workflows/publish-unreal.yml
@@ -1,0 +1,59 @@
+name: Publish Unreal Plugin (GitHub Release)
+
+on:
+  push:
+    tags:
+      - 'unreal/v*'
+
+permissions:
+  contents: write  # Needed to create releases
+
+jobs:
+  publish:
+    name: Package and release Unreal Plugin
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Extract version from tag
+        id: version
+        run: echo "version=${GITHUB_REF_NAME#unreal/v}" >> "$GITHUB_OUTPUT"
+
+      - name: Verify version matches .uplugin
+        run: |
+          UPLUGIN_VERSION=$(python3 -c "
+          import json
+          with open('sdks/unreal/MaestraPlugin/MaestraPlugin.uplugin') as f:
+              print(json.load(f)['VersionName'])
+          ")
+          if [ "$UPLUGIN_VERSION" != "${{ steps.version.outputs.version }}" ]; then
+            echo "::error::Tag version (${{ steps.version.outputs.version }}) does not match .uplugin VersionName ($UPLUGIN_VERSION)"
+            exit 1
+          fi
+
+      - name: Package plugin as zip
+        run: |
+          cd sdks/unreal
+          zip -r "../../MaestraPlugin-${{ steps.version.outputs.version }}.zip" MaestraPlugin/
+          cd ../..
+          echo "Created MaestraPlugin-${{ steps.version.outputs.version }}.zip"
+          ls -lh "MaestraPlugin-${{ steps.version.outputs.version }}.zip"
+
+      - name: Create GitHub Release
+        uses: softprops/action-gh-release@v2
+        with:
+          name: "Unreal Plugin v${{ steps.version.outputs.version }}"
+          body: |
+            ## MaestraPlugin for Unreal Engine 5 — v${{ steps.version.outputs.version }}
+
+            ### Installation
+            1. Download `MaestraPlugin-${{ steps.version.outputs.version }}.zip`
+            2. Extract into your project's `Plugins/` directory
+            3. Regenerate Visual Studio project files
+            4. Build from Visual Studio
+
+            See the [Unreal Engine integration guide](https://maestra.dev/docs/connect/unreal/) for full setup instructions.
+          files: |
+            MaestraPlugin-${{ steps.version.outputs.version }}.zip
+          draft: false
+          prerelease: ${{ contains(steps.version.outputs.version, '-') }}

--- a/.github/workflows/release-sdk.yml
+++ b/.github/workflows/release-sdk.yml
@@ -1,0 +1,120 @@
+name: Release SDK
+
+on:
+  workflow_dispatch:
+    inputs:
+      sdk:
+        description: 'SDK to release'
+        required: true
+        type: choice
+        options:
+          - python
+          - js
+          - arduino
+          - unity
+          - unreal
+          - touchdesigner
+          - all
+      version:
+        description: 'Version (semver, e.g., 0.2.0)'
+        required: true
+        type: string
+      dry_run:
+        description: 'Dry run (bump version but do not tag/push)'
+        required: false
+        type: boolean
+        default: false
+
+permissions:
+  contents: write
+
+jobs:
+  release:
+    name: Bump version and create tag(s)
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+          token: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Set up Node.js (for JSON manipulation)
+        uses: actions/setup-node@v4
+        with:
+          node-version: 20
+
+      - name: Validate version format
+        run: |
+          if ! [[ "${{ inputs.version }}" =~ ^[0-9]+\.[0-9]+\.[0-9]+(-[a-zA-Z0-9.]+)?$ ]]; then
+            echo "::error::Version must be semver format (e.g., 0.2.0, 1.0.0-beta.1)"
+            exit 1
+          fi
+
+      - name: Bump version in manifest(s)
+        run: |
+          chmod +x scripts/bump-sdk-version.sh
+          scripts/bump-sdk-version.sh "${{ inputs.sdk }}" "${{ inputs.version }}"
+
+      - name: Commit version bump
+        run: |
+          git config user.name "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+
+          git add -A
+          if git diff --cached --quiet; then
+            echo "No version changes to commit"
+          else
+            git commit -m "chore: bump ${{ inputs.sdk }} SDK to v${{ inputs.version }}"
+            git push
+          fi
+
+      - name: Create and push tag(s)
+        if: ${{ !inputs.dry_run }}
+        run: |
+          create_tag() {
+            local sdk="$1"
+            local tag="${sdk}/v${{ inputs.version }}"
+            echo "Creating tag: $tag"
+            git tag "$tag" -m "$sdk SDK v${{ inputs.version }}"
+            git push origin "$tag"
+          }
+
+          if [ "${{ inputs.sdk }}" = "all" ]; then
+            create_tag python
+            create_tag js
+            create_tag arduino
+            create_tag unity
+            create_tag unreal
+            create_tag touchdesigner
+          else
+            create_tag "${{ inputs.sdk }}"
+          fi
+
+      - name: Dry run summary
+        if: ${{ inputs.dry_run }}
+        run: |
+          echo "## Dry Run Complete" >> "$GITHUB_STEP_SUMMARY"
+          echo "" >> "$GITHUB_STEP_SUMMARY"
+          echo "Version bumped to **${{ inputs.version }}** for **${{ inputs.sdk }}** SDK(s)." >> "$GITHUB_STEP_SUMMARY"
+          echo "" >> "$GITHUB_STEP_SUMMARY"
+          echo "No tags were created. Run again without dry_run to publish." >> "$GITHUB_STEP_SUMMARY"
+
+      - name: Release summary
+        if: ${{ !inputs.dry_run }}
+        run: |
+          echo "## SDK Release v${{ inputs.version }}" >> "$GITHUB_STEP_SUMMARY"
+          echo "" >> "$GITHUB_STEP_SUMMARY"
+
+          if [ "${{ inputs.sdk }}" = "all" ]; then
+            echo "Tags created for all SDKs:" >> "$GITHUB_STEP_SUMMARY"
+            echo "- \`python/v${{ inputs.version }}\` → PyPI" >> "$GITHUB_STEP_SUMMARY"
+            echo "- \`js/v${{ inputs.version }}\` → npm" >> "$GITHUB_STEP_SUMMARY"
+            echo "- \`arduino/v${{ inputs.version }}\` → PlatformIO" >> "$GITHUB_STEP_SUMMARY"
+            echo "- \`unity/v${{ inputs.version }}\` → OpenUPM" >> "$GITHUB_STEP_SUMMARY"
+            echo "- \`unreal/v${{ inputs.version }}\` → GitHub Release" >> "$GITHUB_STEP_SUMMARY"
+            echo "- \`touchdesigner/v${{ inputs.version }}\` → GitHub Release" >> "$GITHUB_STEP_SUMMARY"
+          else
+            echo "Tag created: \`${{ inputs.sdk }}/v${{ inputs.version }}\`" >> "$GITHUB_STEP_SUMMARY"
+          fi
+          echo "" >> "$GITHUB_STEP_SUMMARY"
+          echo "Per-SDK publish workflows will run automatically." >> "$GITHUB_STEP_SUMMARY"

--- a/Makefile
+++ b/Makefile
@@ -278,9 +278,80 @@ logs-test: ## View test environment logs
 logs-prod: ## View production environment logs
 	$(DOCKER_COMPOSE) -f docker-compose.yml -f docker-compose.prod.yml logs -f
 
+# =============================================================================
+# SDK RELEASES
+# =============================================================================
+# Usage: make release-python VERSION=0.2.0
+#   Bumps version in manifest, commits, tags, and pushes.
+#   The push triggers the corresponding GitHub Actions publish workflow.
+
+VERSION ?= 0.1.0
+
+release-python: ## Release Python SDK to PyPI (VERSION=x.y.z)
+	@scripts/bump-sdk-version.sh python $(VERSION)
+	@git add sdks/python/pyproject.toml
+	@git commit -m "chore: bump Python SDK to v$(VERSION)"
+	@git tag "python/v$(VERSION)" -m "Python SDK v$(VERSION)"
+	@git push && git push origin "python/v$(VERSION)"
+	@echo "✅ Python SDK v$(VERSION) tagged. PyPI publish workflow triggered."
+
+release-js: ## Release JS/TS SDK to npm (VERSION=x.y.z)
+	@scripts/bump-sdk-version.sh js $(VERSION)
+	@git add sdks/js/package.json
+	@git commit -m "chore: bump JS SDK to v$(VERSION)"
+	@git tag "js/v$(VERSION)" -m "JS SDK v$(VERSION)"
+	@git push && git push origin "js/v$(VERSION)"
+	@echo "✅ JS SDK v$(VERSION) tagged. npm publish workflow triggered."
+
+release-arduino: ## Release Arduino SDK to PlatformIO (VERSION=x.y.z)
+	@scripts/bump-sdk-version.sh arduino $(VERSION)
+	@git add sdks/arduino/MaestraClient/library.json
+	@git commit -m "chore: bump Arduino SDK to v$(VERSION)"
+	@git tag "arduino/v$(VERSION)" -m "Arduino SDK v$(VERSION)"
+	@git push && git push origin "arduino/v$(VERSION)"
+	@echo "✅ Arduino SDK v$(VERSION) tagged. PlatformIO publish workflow triggered."
+
+release-unity: ## Release Unity SDK via OpenUPM (VERSION=x.y.z)
+	@scripts/bump-sdk-version.sh unity $(VERSION)
+	@git add sdks/unity/package.json
+	@git commit -m "chore: bump Unity SDK to v$(VERSION)"
+	@git tag "unity/v$(VERSION)" -m "Unity SDK v$(VERSION)"
+	@git push && git push origin "unity/v$(VERSION)"
+	@echo "✅ Unity SDK v$(VERSION) tagged. UPM branch update workflow triggered."
+
+release-unreal: ## Release Unreal Plugin as GitHub Release (VERSION=x.y.z)
+	@scripts/bump-sdk-version.sh unreal $(VERSION)
+	@git add sdks/unreal/MaestraPlugin/MaestraPlugin.uplugin
+	@git commit -m "chore: bump Unreal Plugin to v$(VERSION)"
+	@git tag "unreal/v$(VERSION)" -m "Unreal Plugin v$(VERSION)"
+	@git push && git push origin "unreal/v$(VERSION)"
+	@echo "✅ Unreal Plugin v$(VERSION) tagged. GitHub Release workflow triggered."
+
+release-td: ## Release TouchDesigner SDK as GitHub Release (VERSION=x.y.z)
+	@scripts/bump-sdk-version.sh touchdesigner $(VERSION)
+	@git add sdks/touchdesigner/
+	@git commit --allow-empty -m "chore: bump TouchDesigner SDK to v$(VERSION)"
+	@git tag "touchdesigner/v$(VERSION)" -m "TouchDesigner SDK v$(VERSION)"
+	@git push && git push origin "touchdesigner/v$(VERSION)"
+	@echo "✅ TouchDesigner SDK v$(VERSION) tagged. GitHub Release workflow triggered."
+
+release-all: ## Release all SDKs (VERSION=x.y.z)
+	@scripts/bump-sdk-version.sh all $(VERSION)
+	@git add sdks/
+	@git commit -m "chore: bump all SDKs to v$(VERSION)"
+	@git tag "python/v$(VERSION)" -m "Python SDK v$(VERSION)"
+	@git tag "js/v$(VERSION)" -m "JS SDK v$(VERSION)"
+	@git tag "arduino/v$(VERSION)" -m "Arduino SDK v$(VERSION)"
+	@git tag "unity/v$(VERSION)" -m "Unity SDK v$(VERSION)"
+	@git tag "unreal/v$(VERSION)" -m "Unreal Plugin v$(VERSION)"
+	@git tag "touchdesigner/v$(VERSION)" -m "TouchDesigner SDK v$(VERSION)"
+	@git push && git push origin --tags
+	@echo "✅ All SDKs tagged at v$(VERSION). Publish workflows triggered."
+
 # Development shortcuts
 .PHONY: dev-bus dev-db dev-core shell-postgres shell-redis shell-fleet
 .PHONY: migrate migrate-status migrate-dry-run
 .PHONY: backup-db restore-db test-mqtt test-mqtt-state watch stats update
 .PHONY: deploy-test deploy-prod stop-test stop-prod logs-test logs-prod
 .PHONY: up-dmx dev-dmx logs-dmx build-dmx test-dmx sync-ofl ofl-status update-ip
+.PHONY: release-python release-js release-arduino release-unity release-unreal release-td release-all

--- a/docs/docs/setup/releasing-sdks.md
+++ b/docs/docs/setup/releasing-sdks.md
@@ -1,0 +1,157 @@
+# Releasing SDKs
+
+This guide covers how to publish Maestra SDKs to their respective package registries, and the one-time setup required before the first release.
+
+## Overview
+
+Each SDK has a dedicated GitHub Actions workflow that publishes to the appropriate registry when a Git tag is pushed. A coordinated release workflow and Makefile targets make it easy to bump versions and trigger publishes.
+
+| SDK | Tag Pattern | Publishes To | Secret Required |
+|-----|------------|--------------|-----------------|
+| Python | `python/v*` | PyPI | None (OIDC trusted publisher) |
+| JS/TS | `js/v*` | npm (`@maestra/sdk`) | `NPM_TOKEN` |
+| Arduino | `arduino/v*` | PlatformIO Registry | `PLATFORMIO_AUTH_TOKEN` |
+| Unity | `unity/v*` | `upm` branch + OpenUPM version tag | None |
+| Unreal | `unreal/v*` | GitHub Release (zip) | None |
+| TouchDesigner | `touchdesigner/v*` | GitHub Release (zip) | None |
+
+## How to do a release
+
+### Option A: From the command line
+
+```bash
+# Single SDK
+make release-python VERSION=0.2.0
+
+# All SDKs at once
+make release-all VERSION=0.2.0
+```
+
+Each target bumps the version in the manifest, commits, tags, and pushes — triggering the publish workflow automatically.
+
+Available targets:
+
+```bash
+make release-python VERSION=x.y.z
+make release-js VERSION=x.y.z
+make release-arduino VERSION=x.y.z
+make release-unity VERSION=x.y.z
+make release-unreal VERSION=x.y.z
+make release-td VERSION=x.y.z
+make release-all VERSION=x.y.z
+```
+
+### Option B: From GitHub Actions UI
+
+1. Go to **Actions → Release SDK → Run workflow**
+2. Pick the SDK (or "all"), enter the version
+3. Optionally check **Dry run** to bump versions without publishing
+
+### Option C: Manual tagging
+
+If the version is already bumped in the manifest:
+
+```bash
+git tag python/v0.2.0 -m "Python SDK v0.2.0"
+git push origin python/v0.2.0
+```
+
+All publish workflows verify the tag version matches the manifest version before publishing, so mismatches are caught early.
+
+## Version bump utility
+
+The `scripts/bump-sdk-version.sh` script updates version numbers across SDK manifest files:
+
+```bash
+# Bump a single SDK
+./scripts/bump-sdk-version.sh python 0.2.0
+
+# Bump all SDKs at once
+./scripts/bump-sdk-version.sh all 0.2.0
+```
+
+Supported SDK names: `python`, `js`, `unity`, `unreal`, `arduino`, `touchdesigner`, `all`
+
+The script validates semver format and updates the correct field in each manifest:
+
+| SDK | Manifest File | Field Updated |
+|-----|--------------|---------------|
+| Python | `sdks/python/pyproject.toml` | `version` |
+| JS/TS | `sdks/js/package.json` | `version` |
+| Unity | `sdks/unity/package.json` | `version` |
+| Unreal | `sdks/unreal/MaestraPlugin/MaestraPlugin.uplugin` | `VersionName` |
+| Arduino | `sdks/arduino/MaestraClient/library.json` | `version` |
+| TouchDesigner | _(no manifest)_ | Version tracked via Git tag only |
+
+---
+
+## One-time setup (before first publish)
+
+These steps need to be done **once** by a repo admin. The workflows are ready — they just need the external accounts and secrets configured.
+
+### 1. PyPI (Python SDK)
+
+1. Register or claim the `maestra` package name on [pypi.org](https://pypi.org)
+2. Go to the package's **Settings → Publishing → Add a new publisher**
+3. Select **GitHub Actions** and enter:
+    - **Owner:** `maestra` (or your GitHub org)
+    - **Repository:** `maestra-core`
+    - **Workflow name:** `publish-python.yml`
+    - **Environment:** `pypi`
+4. In the GitHub repo, go to **Settings → Environments → New environment** and create one called `pypi`
+
+No API token needed — PyPI's OIDC trusted publisher handles authentication automatically.
+
+### 2. npm (JS/TS SDK)
+
+1. Create the `@maestra` org on [npmjs.com](https://www.npmjs.com) (or use your existing org)
+2. Go to **Account → Access Tokens → Generate New Token**
+3. Choose **Automation** token type
+4. In the GitHub repo, go to **Settings → Secrets and variables → Actions → New repository secret**
+5. Add secret: Name = `NPM_TOKEN`, Value = the token from step 3
+6. Create a GitHub environment called `npm` under **Settings → Environments**
+
+### 3. PlatformIO (Arduino SDK)
+
+1. Create a [PlatformIO](https://platformio.org) account if you don't have one
+2. Run `pio account token` locally (or generate one from the PlatformIO web UI)
+3. In the GitHub repo, add a repository secret: Name = `PLATFORMIO_AUTH_TOKEN`, Value = the token
+4. Create a GitHub environment called `platformio` under **Settings → Environments**
+
+### 4. OpenUPM (Unity SDK)
+
+1. Go to [openupm.com/packages/add](https://openupm.com/packages/add/)
+2. Submit the package:
+    - **Package name:** `dev.maestra.sdk`
+    - **Repository URL:** `https://github.com/maestra/maestra-core` (or your repo URL)
+    - **Branch:** `upm`
+3. Once approved, Unity developers can install with: `openupm add dev.maestra.sdk`
+
+The `publish-unity.yml` workflow automatically maintains the `upm` branch via `git subtree split`.
+
+### 5. Unreal Fab Store (manual)
+
+The `publish-unreal.yml` workflow creates a GitHub Release with a downloadable zip. To also list on the Fab Store:
+
+1. After a release, download `MaestraPlugin-x.y.z.zip` from the GitHub Release
+2. Go to [fab.com](https://www.fab.com) and submit through the creator portal
+3. This is a manual process — Epic does not offer CI/CD for Fab Store submissions
+
+### 6. TouchDesigner (no external setup)
+
+The `publish-touchdesigner.yml` workflow creates a GitHub Release with a downloadable zip. No external registry to configure. Users download directly from GitHub Releases.
+
+---
+
+## Workflow files reference
+
+| File | Purpose |
+|------|---------|
+| `.github/workflows/publish-python.yml` | Build and publish to PyPI on `python/v*` tag |
+| `.github/workflows/publish-js.yml` | Build and publish to npm on `js/v*` tag |
+| `.github/workflows/publish-arduino.yml` | Publish to PlatformIO on `arduino/v*` tag |
+| `.github/workflows/publish-unity.yml` | Update `upm` branch and tag on `unity/v*` tag |
+| `.github/workflows/publish-unreal.yml` | Create GitHub Release with zip on `unreal/v*` tag |
+| `.github/workflows/publish-touchdesigner.yml` | Create GitHub Release with zip on `touchdesigner/v*` tag |
+| `.github/workflows/release-sdk.yml` | Manual dispatch: bump version, commit, tag, trigger publish |
+| `scripts/bump-sdk-version.sh` | CLI utility to update version in manifest files |

--- a/docs/mkdocs.yml
+++ b/docs/mkdocs.yml
@@ -45,6 +45,7 @@ nav:
       - Installation: setup/installation.md
       - Quick Start (Admin): setup/quickstart.md
       - Configuration: setup/configuration.md
+      - Releasing SDKs: setup/releasing-sdks.md
   - Technical Reference:
       - API Reference:
           - Fleet Manager: api/fleet-manager.md

--- a/scripts/bump-sdk-version.sh
+++ b/scripts/bump-sdk-version.sh
@@ -1,0 +1,113 @@
+#!/usr/bin/env bash
+#
+# Bump the version number in an SDK's manifest file(s).
+#
+# Usage:
+#   ./scripts/bump-sdk-version.sh <sdk> <version>
+#
+# Examples:
+#   ./scripts/bump-sdk-version.sh python 0.2.0
+#   ./scripts/bump-sdk-version.sh js 1.0.0
+#   ./scripts/bump-sdk-version.sh all 0.2.0
+#
+# Supported SDKs: python, js, unity, unreal, arduino, touchdesigner, all
+
+set -euo pipefail
+
+REPO_ROOT="$(cd "$(dirname "$0")/.." && pwd)"
+
+if [[ $# -ne 2 ]]; then
+    echo "Usage: $0 <sdk> <version>"
+    echo "SDKs: python, js, unity, unreal, arduino, touchdesigner, all"
+    exit 1
+fi
+
+SDK="$1"
+VERSION="$2"
+
+# Validate version format (semver-ish)
+if ! [[ "$VERSION" =~ ^[0-9]+\.[0-9]+\.[0-9]+(-[a-zA-Z0-9.]+)?$ ]]; then
+    echo "Error: Version must be in semver format (e.g., 0.2.0, 1.0.0-beta.1)"
+    exit 1
+fi
+
+bump_python() {
+    local file="$REPO_ROOT/sdks/python/pyproject.toml"
+    sed -i.bak -E "s/^version = \"[^\"]+\"/version = \"$VERSION\"/" "$file"
+    rm -f "$file.bak"
+    echo "  Python SDK → $VERSION ($file)"
+}
+
+bump_js() {
+    local file="$REPO_ROOT/sdks/js/package.json"
+    # Use node to preserve JSON formatting
+    node -e "
+        const fs = require('fs');
+        const pkg = JSON.parse(fs.readFileSync('$file', 'utf8'));
+        pkg.version = '$VERSION';
+        fs.writeFileSync('$file', JSON.stringify(pkg, null, 2) + '\n');
+    "
+    echo "  JS/TS SDK → $VERSION ($file)"
+}
+
+bump_unity() {
+    local file="$REPO_ROOT/sdks/unity/package.json"
+    node -e "
+        const fs = require('fs');
+        const pkg = JSON.parse(fs.readFileSync('$file', 'utf8'));
+        pkg.version = '$VERSION';
+        fs.writeFileSync('$file', JSON.stringify(pkg, null, 2) + '\n');
+    "
+    echo "  Unity SDK → $VERSION ($file)"
+}
+
+bump_unreal() {
+    local file="$REPO_ROOT/sdks/unreal/MaestraPlugin/MaestraPlugin.uplugin"
+    # Update VersionName string
+    sed -i.bak -E "s/\"VersionName\": \"[^\"]+\"/\"VersionName\": \"$VERSION\"/" "$file"
+    rm -f "$file.bak"
+    echo "  Unreal Plugin → $VERSION ($file)"
+}
+
+bump_arduino() {
+    local file="$REPO_ROOT/sdks/arduino/MaestraClient/library.json"
+    node -e "
+        const fs = require('fs');
+        const pkg = JSON.parse(fs.readFileSync('$file', 'utf8'));
+        pkg.version = '$VERSION';
+        fs.writeFileSync('$file', JSON.stringify(pkg, null, 2) + '\n');
+    "
+    echo "  Arduino SDK → $VERSION ($file)"
+}
+
+bump_touchdesigner() {
+    # TouchDesigner has no manifest with a version field.
+    # Version is tracked via Git tags only.
+    echo "  TouchDesigner → $VERSION (version tracked via Git tag only)"
+}
+
+echo "Bumping SDK version to $VERSION:"
+
+case "$SDK" in
+    python)        bump_python ;;
+    js)            bump_js ;;
+    unity)         bump_unity ;;
+    unreal)        bump_unreal ;;
+    arduino)       bump_arduino ;;
+    touchdesigner) bump_touchdesigner ;;
+    all)
+        bump_python
+        bump_js
+        bump_unity
+        bump_unreal
+        bump_arduino
+        bump_touchdesigner
+        ;;
+    *)
+        echo "Error: Unknown SDK '$SDK'"
+        echo "Valid SDKs: python, js, unity, unreal, arduino, touchdesigner, all"
+        exit 1
+        ;;
+esac
+
+echo "Done."

--- a/sdks/arduino/MaestraClient/library.json
+++ b/sdks/arduino/MaestraClient/library.json
@@ -2,7 +2,13 @@
   "name": "MaestraClient",
   "version": "0.1.0",
   "description": "Arduino/ESP32 SDK for Maestra immersive experience platform",
-  "keywords": ["maestra", "mqtt", "iot", "esp32", "state-management"],
+  "keywords": [
+    "maestra",
+    "mqtt",
+    "iot",
+    "esp32",
+    "state-management"
+  ],
   "authors": [
     {
       "name": "Maestra Team"
@@ -13,8 +19,14 @@
     "url": "https://github.com/maestra/maestra-core"
   },
   "license": "MIT",
-  "frameworks": ["arduino"],
-  "platforms": ["espressif32", "espressif8266", "atmelavr"],
+  "frameworks": [
+    "arduino"
+  ],
+  "platforms": [
+    "espressif32",
+    "espressif8266",
+    "atmelavr"
+  ],
   "dependencies": {
     "knolleary/PubSubClient": "^2.8",
     "bblanchon/ArduinoJson": "^7.0.0"


### PR DESCRIPTION
## SDK Distribution & Deployment Workflows

### What's included

**Version bump utility** (`scripts/bump-sdk-version.sh`)
Updates version numbers across all SDK manifest files. Supports individual SDKs or `all` at once.

**6 per-SDK publish workflows** (triggered automatically by Git tags):

| Workflow | Tag Pattern | Publishes To | Secret Required |
|----------|------------|--------------|-----------------|
| `publish-python.yml` | `python/v*` | PyPI | None (OIDC trusted publisher) |
| `publish-js.yml` | `js/v*` | npm (`@maestra/sdk`) | `NPM_TOKEN` |
| `publish-arduino.yml` | `arduino/v*` | PlatformIO Registry | `PLATFORMIO_AUTH_TOKEN` |
| `publish-unity.yml` | `unity/v*` | `upm` branch + OpenUPM version tag | None |
| `publish-unreal.yml` | `unreal/v*` | GitHub Release (zip) | None |
| `publish-touchdesigner.yml` | `touchdesigner/v*` | GitHub Release (zip) | None |

**Coordinated release workflow** (`release-sdk.yml`)
Manual dispatch from GitHub Actions UI — pick an SDK (or "all"), enter a version, optionally dry-run. Bumps manifests, commits, creates tags, which triggers the per-SDK workflows above.

**Makefile targets** for local release flow:
```bash
make release-python VERSION=0.2.0
make release-js VERSION=0.2.0
make release-arduino VERSION=0.2.0
make release-unity VERSION=0.2.0
make release-unreal VERSION=0.2.0
make release-td VERSION=0.2.0
make release-all VERSION=0.2.0    # all SDKs at once
