### PR TITLE
DMX Groups, multi-group playback, sequence control params, and entity state sync

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,4 @@
 [submodule "vendor/ofl"]
 	path = vendor/ofl
-	url = https://github.com/OpenLightingProject/open-fixture-library.git
+	url = https://github.com/aarongeiser/open-fixture-library.git
+	branch = branch2026-03-23T04-51-04

--- a/config/postgres/migrations/018_dmx_groups.sql
+++ b/config/postgres/migrations/018_dmx_groups.sql
@@ -1,0 +1,41 @@
+-- Migration 018: DMX Groups & Layer System
+-- Adds dmx_groups table and group_id FK columns on fixtures, cues, and sequences.
+-- All existing rows get group_id = NULL (ungrouped), preserving full backward compatibility.
+
+-- ── Groups table ─────────────────────────────────────────────────────────────
+
+CREATE TABLE IF NOT EXISTS dmx_groups (
+    id          UUID        PRIMARY KEY DEFAULT gen_random_uuid(),
+    name        TEXT        NOT NULL,
+    color       TEXT,
+    sort_order  INTEGER     NOT NULL DEFAULT 0,
+    metadata    JSONB       NOT NULL DEFAULT '{}',
+    created_at  TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+    updated_at  TIMESTAMPTZ NOT NULL DEFAULT NOW()
+);
+
+CREATE INDEX IF NOT EXISTS idx_dmx_groups_sort_order ON dmx_groups (sort_order);
+
+-- ── group_id on fixtures ──────────────────────────────────────────────────────
+
+ALTER TABLE dmx_fixtures
+    ADD COLUMN IF NOT EXISTS group_id UUID
+        REFERENCES dmx_groups(id) ON DELETE SET NULL;
+
+CREATE INDEX IF NOT EXISTS idx_dmx_fixtures_group_id ON dmx_fixtures (group_id);
+
+-- ── group_id on cues ──────────────────────────────────────────────────────────
+
+ALTER TABLE dmx_cues
+    ADD COLUMN IF NOT EXISTS group_id UUID
+        REFERENCES dmx_groups(id) ON DELETE SET NULL;
+
+CREATE INDEX IF NOT EXISTS idx_dmx_cues_group_id ON dmx_cues (group_id);
+
+-- ── group_id on sequences ─────────────────────────────────────────────────────
+
+ALTER TABLE dmx_sequences
+    ADD COLUMN IF NOT EXISTS group_id UUID
+        REFERENCES dmx_groups(id) ON DELETE SET NULL;
+
+CREATE INDEX IF NOT EXISTS idx_dmx_sequences_group_id ON dmx_sequences (group_id);

--- a/config/postgres/migrations/019_dmx_lighting_groups_state.sql
+++ b/config/postgres/migrations/019_dmx_lighting_groups_state.sql
@@ -1,0 +1,118 @@
+-- 019_dmx_lighting_groups_state.sql
+-- Extend the DMX Lighting entity type schema to include groups, per-item group_id
+-- fields on cues and sequences, and a group_playback map for independent per-group
+-- sequence/cue control via OSC, MQTT, or NATS entity state updates.
+--
+-- State shape after this migration:
+--
+--   {
+--     "groups": [{"id": "...", "name": "...", "color": "..."}],
+--     "cues": [{"id": "...", "name": "...", "fade_duration": 0, "group_id": null}],
+--     "sequences": [{"id": "...", "name": "...", "cue_count": 0,
+--                    "fade_out_duration": 3, "group_id": null}],
+--     "active_cue_id": null,           -- ungrouped/legacy cue control
+--     "active_sequence_id": null,      -- ungrouped/legacy sequence control
+--     "group_playback": {              -- per-group control (keys are group UUIDs)
+--       "<group-uuid>": {
+--         "active_sequence_id": null,
+--         "active_cue_id": null
+--       }
+--     }
+--   }
+--
+-- External devices control per-group playback by sending a state update with:
+--   PATCH /entities/<id>/state
+--   { "state": { "group_playback": { "<group-id>": { "active_sequence_id": "<seq-id>" } } } }
+--
+-- Or via OSC:  /entity/update/dmx-lighting/group_playback  (JSON object value)
+-- Or via MQTT: maestra/entity/state/update/dmx-lighting
+
+UPDATE entity_types
+SET
+    state_schema  = '{
+        "type": "object",
+        "properties": {
+            "groups": {
+                "type": "array",
+                "description": "All defined DMX groups (layers).",
+                "items": {
+                    "type": "object",
+                    "properties": {
+                        "id":    {"type": "string"},
+                        "name":  {"type": "string"},
+                        "color": {"type": ["string", "null"]}
+                    }
+                }
+            },
+            "cues": {
+                "type": "array",
+                "description": "All saved cues.",
+                "items": {
+                    "type": "object",
+                    "properties": {
+                        "id":            {"type": "string"},
+                        "name":          {"type": "string"},
+                        "fade_duration": {"type": "number"},
+                        "group_id":      {"type": ["string", "null"]}
+                    }
+                }
+            },
+            "sequences": {
+                "type": "array",
+                "description": "All saved sequences.",
+                "items": {
+                    "type": "object",
+                    "properties": {
+                        "id":                {"type": "string"},
+                        "name":              {"type": "string"},
+                        "cue_count":         {"type": "integer"},
+                        "fade_out_duration": {"type": "number"},
+                        "group_id":          {"type": ["string", "null"]}
+                    }
+                }
+            },
+            "active_cue_id": {
+                "type": ["string", "null"],
+                "description": "Recall a cue on the ungrouped (legacy) engine. Set to null to clear."
+            },
+            "active_sequence_id": {
+                "type": ["string", "null"],
+                "description": "Play a sequence on the ungrouped (legacy) engine. Set to null to stop."
+            },
+            "group_playback": {
+                "type": "object",
+                "description": "Per-group playback control. Each key is a group UUID. Set active_sequence_id or active_cue_id to trigger playback on that group engine independently.",
+                "additionalProperties": {
+                    "type": "object",
+                    "properties": {
+                        "active_sequence_id": {"type": ["string", "null"]},
+                        "active_cue_id":      {"type": ["string", "null"]}
+                    }
+                }
+            }
+        }
+    }',
+    default_state = '{
+        "groups": [],
+        "cues": [],
+        "sequences": [],
+        "active_cue_id": null,
+        "active_sequence_id": null,
+        "group_playback": {}
+    }',
+    updated_at = NOW()
+WHERE name = 'dmx_controller';
+
+-- Patch the singleton entity's existing state to add the new top-level keys
+-- without overwriting active playback fields already present.
+UPDATE entities
+SET
+    state = state
+        || '{"groups": []}'::jsonb
+        || jsonb_build_object(
+               'group_playback',
+               COALESCE(state->'group_playback', '{}'::jsonb)
+           ),
+    state_updated_at = NOW()
+WHERE slug = 'dmx-lighting'
+  AND (state->'groups' IS NULL OR state->'group_playback' IS NULL);

--- a/config/postgres/migrations/020_dmx_lighting_seq_control_schema.sql
+++ b/config/postgres/migrations/020_dmx_lighting_seq_control_schema.sql
@@ -1,0 +1,101 @@
+-- 020_dmx_lighting_seq_control_schema.sql
+-- Update the dmx_controller entity type state_schema so that active_sequence_id
+-- and group_playback[].active_sequence_id accept either a plain sequence UUID string
+-- or a control object with optional loop and fadeout parameters.
+
+UPDATE entity_types
+SET
+    state_schema = '{
+        "type": "object",
+        "properties": {
+            "groups": {
+                "type": "array",
+                "description": "All defined DMX groups (layers).",
+                "items": {
+                    "type": "object",
+                    "properties": {
+                        "id":    {"type": "string"},
+                        "name":  {"type": "string"},
+                        "color": {"type": ["string", "null"]}
+                    }
+                }
+            },
+            "cues": {
+                "type": "array",
+                "description": "All saved cues.",
+                "items": {
+                    "type": "object",
+                    "properties": {
+                        "id":            {"type": "string"},
+                        "name":          {"type": "string"},
+                        "fade_duration": {"type": "number"},
+                        "group_id":      {"type": ["string", "null"]}
+                    }
+                }
+            },
+            "sequences": {
+                "type": "array",
+                "description": "All saved sequences.",
+                "items": {
+                    "type": "object",
+                    "properties": {
+                        "id":                {"type": "string"},
+                        "name":              {"type": "string"},
+                        "cue_count":         {"type": "integer"},
+                        "fade_out_duration": {"type": "number"},
+                        "group_id":          {"type": ["string", "null"]}
+                    }
+                }
+            },
+            "active_cue_id": {
+                "type": ["string", "null"],
+                "description": "Recall a cue on the ungrouped engine. Set to null to clear."
+            },
+            "active_sequence_id": {
+                "description": "Play a sequence on the ungrouped engine. Accepts a sequence UUID string (play once, stop on last values) or a control object.",
+                "oneOf": [
+                    {
+                        "type": ["string", "null"],
+                        "description": "Sequence UUID — plays once then stops on last DMX values. Null stops playback."
+                    },
+                    {
+                        "type": "object",
+                        "description": "Control object with playback options.",
+                        "required": ["id"],
+                        "properties": {
+                            "id":      {"type": "string", "description": "Sequence UUID"},
+                            "loop":    {"type": "boolean", "description": "Loop the sequence indefinitely. Default: false."},
+                            "fadeout": {"type": "number", "description": "After the sequence completes (non-looping), fade dimmer channels to zero over this many seconds. Omit to leave the last DMX values in place."}
+                        }
+                    }
+                ]
+            },
+            "group_playback": {
+                "type": "object",
+                "description": "Per-group playback control. Each key is a group UUID.",
+                "additionalProperties": {
+                    "type": "object",
+                    "properties": {
+                        "active_cue_id": {"type": ["string", "null"]},
+                        "active_sequence_id": {
+                            "description": "Same as top-level active_sequence_id — string UUID or control object.",
+                            "oneOf": [
+                                {"type": ["string", "null"]},
+                                {
+                                    "type": "object",
+                                    "required": ["id"],
+                                    "properties": {
+                                        "id":      {"type": "string"},
+                                        "loop":    {"type": "boolean"},
+                                        "fadeout": {"type": "number"}
+                                    }
+                                }
+                            ]
+                        }
+                    }
+                }
+            }
+        }
+    }',
+    updated_at = NOW()
+WHERE name = 'dmx_controller';

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -176,8 +176,7 @@ services:
       - "3001:3000"
     volumes:
       - ./services/dashboard:/app
-      - /app/node_modules
-      - /app/.next
+      - dashboard-next:/app/.next
       - ./VERSION:/etc/maestra-version:ro
     networks:
       - maestra-network
@@ -420,3 +419,4 @@ volumes:
   nodered-data:
   grafana-data:
   portainer-data:
+  dashboard-next:

--- a/docs/docs/guides/dmx-gateway.md
+++ b/docs/docs/guides/dmx-gateway.md
@@ -103,10 +103,28 @@ Each fixture node shows:
 - Click a fixture to select it
 - Shift-click fixtures of the same OFL model + universe to multi-select
 - Click empty canvas to deselect all
+- Double-click a fixture to open the DMX Adjust modal directly
+
+**Group mode (when a group is selected in the Groups tab):**
+
+The canvas switches into group assignment mode. Fixtures render differently based on their group membership:
+
+| State | Visual |
+|---|---|
+| In the selected group | Bright colored ring with glow |
+| Not in any group (eligible) | Faint dashed ring |
+| In a different group | Dimmed, cursor shows not-allowed |
+
+Shift-click any eligible or in-group fixture to toggle its membership. Ineligible fixtures (in a different group) cannot be shift-clicked.
+
+When viewing the Cues or Sequences tab, the canvas shows the same group highlight for the selected group context (read-only — shift-click assignment is only active in the Groups tab).
+
+**Multi-select actions:**
+- Select multiple fixtures to reveal an **Adjust DMX** button in the top-center of the canvas
+- All selected fixtures are adjusted simultaneously
 
 **Context menu (right-click):**
 - Edit fixture settings
-- Copy fixture (duplicates with auto-incremented name)
 - Adjust DMX channels (opens the channel slider modal)
 - Delete fixture
 
@@ -114,59 +132,98 @@ Each fixture node shows:
 
 | Control | Description |
 |---------|-------------|
-| **Pause / Resume Listening** | Pauses all external entity state sources from driving DMX output. Manual Adjust DMX sliders and cue/sequence playback still work when paused. |
+| **Pause / Resume Listening** | Pauses all external entity state sources from driving DMX output. Manual Adjust DMX sliders, cue recall, and sequence playback continue to work while paused. |
 | **Clear** | *(only visible when paused)* Zeros all DMX channel values across every fixture and universe immediately. Requires confirmation. |
+| **Blackout** | Instantly zeros all DMX channels across all universes without pausing. Double-click to blackout and pause simultaneously. |
 | **S / M / L** | Node size picker — persisted in localStorage. |
 
 When external signals are paused, an amber **"External signals paused"** badge appears in the toolbar as a persistent reminder.
 
+Recalling a cue while paused automatically resumes output first, since cue recall is an intentional fire action.
+
 #### Right Sidebar
 
-The sidebar has three collapsible sections:
+The sidebar has five collapsible tabs:
 
-**Nodes & Fixtures**
+**Art-Net Nodes**
 
-Lists all Art-Net nodes grouped by universe. Each node shows its IP address and universe labels. Fixtures appear beneath their parent node, color-coded by universe. You can:
-- Drag fixtures and nodes to reorder them
+Lists all configured Art-Net nodes. Each node shows its IP address and universe labels. You can drag to reorder, click the edit icon to open the node editor, or click **+ Add Node** at the top to add another.
+
+**Fixtures**
+
+Lists all fixtures, color-coded by universe. You can:
+- Drag fixtures to reorder them
 - Click a fixture to select it on the canvas
+- Filter by universe using the dropdown
 - Click the edit icon to open the fixture editor
+
+**Groups**
+
+Groups (also called layers) let you organize fixtures, cues, and sequences into independent playback lanes. Each group has its own playback engine — sequences in different groups run simultaneously without interfering with each other.
+
+| Action | How |
+|--------|-----|
+| Create a group | Click **+ New Group**, enter a name, pick a color |
+| Select a group | Click the group row — the canvas highlights which fixtures are in the group |
+| Assign fixtures to a group | Select the group, then **shift-click** fixtures on the canvas |
+| Remove a fixture from a group | Select the group, shift-click the fixture again (toggles) |
+| Rename / recolor a group | Click the pencil icon on the group row |
+| Delete a group | Click the trash icon — fixtures and cues are unlinked, not deleted |
+
+While a group is selected, fixture nodes on the canvas render in three states:
+
+| Canvas state | Meaning |
+|---|---|
+| Bright colored ring + glow | In this group |
+| Faint dashed ring | Unassigned — eligible to add |
+| Dimmed, no-drop cursor | Belongs to another group — cannot be shift-clicked |
+
+Selecting **All** at the top of the group list clears the selection and shows the full canvas without any highlighting.
+
+A green pulse indicator appears on each group row whenever that group has an active sequence engine running, so you can see what's playing across all groups at a glance.
 
 **Cues**
 
-Cues are snapshots of all linked fixture states at a moment in time.
+Cues are snapshots of all linked fixture states at a moment in time. Cues can optionally belong to a group.
 
 | Action | How |
 |--------|-----|
-| Save current state as cue | Click **+ Save Cue** at the bottom of the Cues panel |
+| Save current state as cue | Pause signals first, then click **+ Save Cue** at the top of the Cues panel |
 | Recall a cue | Click the cue row — a fade-progress bar shows cross-fade progress |
-| Recall with custom fade | Click the cue fade icon and set a duration (seconds), then click Recall |
-| Edit a cue (update snapshot) | Click the pencil icon → adjust DMX sliders → click **Save** |
-| Rename a cue | Double-click the cue name or click the rename icon |
+| Recall with custom fade | Set the **Fade** duration (seconds) at the top of the panel, then click any cue |
+| Edit a cue (update snapshot) | Click the pencil icon → adjust DMX sliders → click **Update Cue** |
+| Rename a cue | Click the rename icon on the cue row |
 | Reorder cues | Drag the handle on the left of each cue row |
 | Delete a cue | Click the trash icon on the cue row |
 
-The currently active cue is highlighted. Moving any DMX slider while not in Edit Mode clears the active cue highlight.
+The group context pill bar at the top of the Cues section filters the cue list to a specific group. Clicking **All** shows all cues across all groups. The canvas reflects the selected group context even while browsing cues.
+
+The currently active cue is highlighted in amber. Moving any DMX slider while not in Edit Mode clears the active cue highlight.
 
 **Sequences**
 
-Sequences chain cues together for automated playback with configurable transitions and hold durations.
+Sequences chain cues together for automated playback with configurable transitions and hold durations. Each sequence belongs to a group (or is ungrouped), and sequences in different groups play simultaneously on independent engines.
 
 | Action | How |
 |--------|-----|
-| Create sequence | Click **+ New Sequence** |
-| Add cue to sequence | Open the sequence, click **+ Add Cue**, pick from the list |
+| Create sequence | Click **+** next to the Sequences header |
+| Add cue to sequence | Open the sequence, click **+ Add Cue**, pick from the list (filtered to the sequence's group) |
 | Set transition time | Click the transition field on a cue placement row (seconds) |
-| Set hold duration | Click the hold field on a cue placement row (seconds, `0` = loop immediately) |
+| Set hold duration | Click the hold field on a cue placement row (seconds; `0` = advance immediately) |
 | Reorder cues in sequence | Drag the handle on each placement row |
 | Remove cue from sequence | Click the × on a placement row |
-| Play sequence | Click the **▶** button on the sequence header |
+| Play sequence | Click **▶** on the sequence header |
 | Pause / Resume | Click **⏸** or **▶** while playing |
 | Stop | Click **⏹** |
 | Toggle loop | Click the loop icon — loops indefinitely when enabled |
-| Fade out | Click the fade icon and set duration (seconds) — fades dimmer/intensity channels to zero then stops |
-| Rename sequence | Click the sequence name |
+| Fade out | Click the sunset icon — fades dimmer/intensity channels to zero then stops; duration set by the **Fade Out** control at the top of the section |
+| Rename sequence | Click the pencil icon on the sequence header |
 | Reorder sequences | Drag the sequence header row |
 | Delete sequence | Click the trash icon (requires confirmation if sequence has cues) |
+
+The group context pill bar at the top filters visible sequences to one group while still showing green pulse dots on all pills that have an active engine running. Clicking **All** shows every sequence across all groups. Because each group has an independent playback engine, you can play sequences from multiple groups at the same time — they do not interrupt each other.
+
+A green pulse dot appears on the Sequences tab header when any group engine is active.
 
 #### DMX Adjust Modal
 
@@ -203,34 +260,94 @@ Adding a node automatically creates a linked Maestra **Device** for it, which ap
 
 Maestra automatically creates a singleton entity called **DMX Lighting** (`slug: dmx-lighting`, type: `dmx_controller`). This entity:
 
-- **Reflects the cue and sequence catalog** in its state — any external tool subscribed to `maestra.entity.state.dmx_controller.dmx-lighting` sees the full list of cues and sequences plus the currently active IDs
-- **Enables external triggering** — PATCH the entity's `active_cue_id` or `active_sequence_id` fields from any SDK to recall a cue or start a sequence from outside the Dashboard
-- **Updates in real time** — the entity state is synced on every cue/sequence create, rename, reorder, or delete
+- **Reflects the full catalog** — groups, cues (with group membership), and sequences (with group membership) are all exposed in the entity state
+- **Enables external triggering** — any SDK, OSC message, MQTT topic, or NATS subject can start/stop playback by patching the entity state
+- **Supports simultaneous multi-group control** — each group has an independent playback engine; the `group_playback` field lets you address them independently
+- **Updates in real time** — the entity state is synced on every group/cue/sequence create, rename, reorder, or delete
 
-The entity state shape:
+### Entity state shape
 
 ```json
 {
+  "groups": [
+    { "id": "uuid", "name": "Center Grid", "color": "#ef4444" }
+  ],
   "cues": [
-    { "id": "uuid", "name": "Warm Stage", "fade_duration": 2.5 }
+    { "id": "uuid", "name": "Warm Stage", "fade_duration": 2.5, "group_id": "uuid-or-null" }
   ],
   "sequences": [
-    { "id": "uuid", "name": "Opening Show", "cue_count": 4, "fade_out_duration": 3.0 }
+    { "id": "uuid", "name": "Opening Show", "cue_count": 4, "fade_out_duration": 3.0, "group_id": "uuid-or-null" }
   ],
   "active_cue_id": "uuid-or-null",
-  "active_sequence_id": "uuid-or-null"
+  "active_sequence_id": "uuid-or-null",
+  "group_playback": {
+    "<group-uuid>": {
+      "active_sequence_id": "uuid-or-null",
+      "active_cue_id": "uuid-or-null"
+    }
+  }
 }
 ```
 
-To trigger a cue from any external tool:
+### Ungrouped (legacy) control
+
+Set `active_cue_id` to recall a cue on the ungrouped engine, or `active_sequence_id` to play a sequence. Set either to `null` to clear/stop. This is backward-compatible with any integration built before Groups were introduced.
 
 ```bash
+# Recall a cue
 curl -X PATCH http://localhost:8080/entities/dmx-lighting/state \
   -H "Content-Type: application/json" \
   -d '{"state": {"active_cue_id": "<cue-uuid>"}}'
+
+# Play a sequence
+curl -X PATCH http://localhost:8080/entities/dmx-lighting/state \
+  -H "Content-Type: application/json" \
+  -d '{"state": {"active_sequence_id": "<sequence-uuid>"}}'
+
+# Stop ungrouped playback
+curl -X PATCH http://localhost:8080/entities/dmx-lighting/state \
+  -H "Content-Type: application/json" \
+  -d '{"state": {"active_sequence_id": null, "active_cue_id": null}}'
 ```
 
-The Dashboard subscribes to `maestra.entity.state.dmx_controller.dmx-lighting` via WebSocket and updates cue/sequence highlights in real time when triggered externally.
+### Per-group control
+
+Use the `group_playback` field to address any group engine independently. Multiple groups can be started or stopped in a single state update:
+
+```bash
+# Play different sequences on two groups simultaneously
+curl -X PATCH http://localhost:8080/entities/dmx-lighting/state \
+  -H "Content-Type: application/json" \
+  -d '{
+    "state": {
+      "group_playback": {
+        "<group-a-uuid>": { "active_sequence_id": "<seq-uuid-A>" },
+        "<group-b-uuid>": { "active_sequence_id": "<seq-uuid-B>" }
+      }
+    }
+  }'
+
+# Stop one group while leaving the other running
+curl -X PATCH http://localhost:8080/entities/dmx-lighting/state \
+  -H "Content-Type: application/json" \
+  -d '{
+    "state": {
+      "group_playback": {
+        "<group-a-uuid>": { "active_sequence_id": null, "active_cue_id": null }
+      }
+    }
+  }'
+```
+
+The same control is available via any Maestra gateway:
+
+- **OSC:** `/entity/update/dmx-lighting/group_playback` with a JSON object value
+- **MQTT:** publish to `maestra/entity/state/update/dmx-lighting`
+- **NATS:** publish to `maestra.entity.state.update.dmx-lighting`
+
+The `group_playback` field in the entity state is hydrated from the live engine registry on every catalog sync, so external tools can read it to know what is currently playing on each group engine.
+
+The Dashboard subscribes to `maestra.entity.state.dmx_controller.dmx-lighting` via WebSocket and updates cue/sequence highlights and group activity indicators in real time when triggered externally.
 
 ---
 
@@ -270,6 +387,19 @@ nats sub 'maestra.dmx.fixture.>'
 
 All DMX configuration is managed via the Fleet Manager API. Full interactive docs at `http://localhost:8080/docs`.
 
+### Groups (`/dmx/groups`)
+
+Groups organize fixtures, cues, and sequences into independent playback layers. Each group runs its own playback engine, allowing simultaneous sequence playback across groups.
+
+| Method | Endpoint | Description |
+|--------|----------|-------------|
+| `GET` | `/dmx/groups` | List all groups ordered by sort_order |
+| `POST` | `/dmx/groups` | Create a new group (`{"name": "Stage Left", "color": "#ef4444"}`) |
+| `GET` | `/dmx/groups/{id}` | Get a group with fixture/cue/sequence counts |
+| `PATCH` | `/dmx/groups/{id}` | Update name, color, or sort_order |
+| `DELETE` | `/dmx/groups/{id}` | Delete a group (fixtures/cues/sequences are unlinked, not deleted) |
+| `PUT` | `/dmx/groups/{id}/fixtures` | Bulk assign fixtures to this group (body: `["fixture-id", ...]`; empty list unassigns all) |
+
 ### Art-Net Nodes (`/dmx/nodes`)
 
 | Method | Endpoint | Description |
@@ -305,12 +435,12 @@ All DMX configuration is managed via the Fleet Manager API. Full interactive doc
 
 ### Cues (`/dmx/cues`)
 
-Cues are named snapshots of all linked fixture states.
+Cues are named snapshots of all linked fixture states. Each cue optionally belongs to a group.
 
 | Method | Endpoint | Description |
 |--------|----------|-------------|
 | `GET` | `/dmx/cues` | List all cues ordered by sort_order |
-| `POST` | `/dmx/cues` | Save current entity states as a new cue (`{"name": "My Cue"}`) |
+| `POST` | `/dmx/cues` | Save current entity states as a new cue (`{"name": "My Cue", "group_id": "uuid-or-omit"}`) |
 | `PUT` | `/dmx/cues/reorder` | Reorder cues (body: `["id1","id2",...]`) |
 | `POST` | `/dmx/cues/{id}/recall` | Instantly restore all fixture states from this cue |
 | `POST` | `/dmx/cues/{id}/snapshot` | Replace cue fixture data with current entity states (Edit Mode save) |
@@ -320,12 +450,12 @@ Cues are named snapshots of all linked fixture states.
 
 ### Sequences (`/dmx/sequences`)
 
-Sequences chain cues with configurable transitions and hold durations.
+Sequences chain cues with configurable transitions and hold durations. Each sequence optionally belongs to a group — sequences in different groups run on independent engines and play simultaneously.
 
 | Method | Endpoint | Description |
 |--------|----------|-------------|
 | `GET` | `/dmx/sequences` | List all sequences with their cue placements |
-| `POST` | `/dmx/sequences` | Create a new empty sequence (`{"name": "My Sequence"}`) |
+| `POST` | `/dmx/sequences` | Create a new empty sequence (`{"name": "My Sequence", "group_id": "uuid-or-omit"}`) |
 | `PUT` | `/dmx/sequences/reorder` | Reorder sequences (body: `["id1","id2",...]`) |
 | `PUT` | `/dmx/sequences/{id}` | Rename a sequence |
 | `DELETE` | `/dmx/sequences/{id}` | Delete a sequence |
@@ -346,25 +476,29 @@ Sequences chain cues with configurable transitions and hold durations.
 
 The backend playback engine runs sequence playback at 80ms intervals, interpolating fixture states between cues and broadcasting entity state changes via NATS.
 
+All playback endpoints accept an optional `?group_id=<uuid>` query parameter to target a specific group's engine. Omitting `group_id` targets the ungrouped (legacy) engine. Pass `?group_id=all` to `GET /dmx/playback/status` to retrieve statuses for all active engines in one request.
+
 | Method | Endpoint | Description |
 |--------|----------|-------------|
-| `GET` | `/dmx/playback/status` | Get current playback engine state |
-| `POST` | `/dmx/playback/play` | Start sequence playback |
-| `POST` | `/dmx/playback/pause` | Pause playback (holds current frame) |
+| `GET` | `/dmx/playback/status` | Get ungrouped engine state (add `?group_id=<uuid>` for a specific group, `?group_id=all` for all) |
+| `POST` | `/dmx/playback/play` | Start sequence playback (`?group_id=<uuid>` to target a group engine) |
+| `POST` | `/dmx/playback/pause` | Pause playback |
 | `POST` | `/dmx/playback/resume` | Resume paused playback |
 | `POST` | `/dmx/playback/stop` | Stop playback |
 | `POST` | `/dmx/playback/toggle-loop` | Toggle loop mode, returns `{"loop": bool}` |
 | `POST` | `/dmx/playback/fadeout` | Fade dimmer channels to zero then stop |
 | `POST` | `/dmx/playback/cue-fade` | Cross-fade from one cue snapshot to another |
+| `POST` | `/dmx/playback/blackout` | Zero all DMX channels immediately across all universes |
 
 **Play request:**
 ```json
 { "sequence_id": "uuid" }
 ```
 
-**Playback status response:**
+**Single-engine status response (`GET /dmx/playback/status`):**
 ```json
 {
+  "group_id": "uuid-or-null",
   "sequence_id": "uuid-or-null",
   "play_state": "stopped | playing | paused",
   "phase": "idle | transitioning | holding",
@@ -373,6 +507,16 @@ The backend playback engine runs sequence playback at 80ms intervals, interpolat
   "hold_progress": 0.3,
   "loop": false,
   "fade_progress": null
+}
+```
+
+**All-engines status response (`GET /dmx/playback/status?group_id=all`):**
+```json
+{
+  "engines": [
+    { "group_id": null, "sequence_id": null, "play_state": "stopped", ... },
+    { "group_id": "abc-uuid", "sequence_id": "seq-uuid", "play_state": "playing", ... }
+  ]
 }
 ```
 

--- a/docs/docs/guides/dmx-gateway.md
+++ b/docs/docs/guides/dmx-gateway.md
@@ -279,15 +279,57 @@ Maestra automatically creates a singleton entity called **DMX Lighting** (`slug:
     { "id": "uuid", "name": "Opening Show", "cue_count": 4, "fade_out_duration": 3.0, "group_id": "uuid-or-null" }
   ],
   "active_cue_id": "uuid-or-null",
-  "active_sequence_id": "uuid-or-null",
+  "active_sequence_id": "uuid-or-null-or-control-object",
   "group_playback": {
     "<group-uuid>": {
-      "active_sequence_id": "uuid-or-null",
+      "active_sequence_id": "uuid-or-null-or-control-object",
       "active_cue_id": "uuid-or-null"
     }
   }
 }
 ```
+
+### Sequence playback options
+
+`active_sequence_id` (both at the top level and inside each `group_playback` entry) accepts either a plain string UUID **or** a control object with additional playback parameters:
+
+**Plain string** — play once, hold last DMX values when the final cue completes:
+```json
+"active_sequence_id": "<sequence-uuid>"
+```
+
+**Control object** — specify loop or fade-out behavior:
+```json
+"active_sequence_id": {
+  "id": "<sequence-uuid>",
+  "loop": true
+}
+```
+
+```json
+"active_sequence_id": {
+  "id": "<sequence-uuid>",
+  "fadeout": 3.0
+}
+```
+
+| Field | Type | Default | Description |
+|-------|------|---------|-------------|
+| `id` | string | required | UUID of the sequence to play |
+| `loop` | boolean | `false` | Repeat indefinitely once the last cue completes |
+| `fadeout` | number | omit | After the final cue, fade all dimmer/intensity channels to zero over this many seconds, then stop |
+
+**Behavior summary:**
+
+| `loop` | `fadeout` | On completion |
+|--------|-----------|---------------|
+| `false` | omitted | Last DMX values remain in place |
+| `true` | omitted | Sequence restarts from the first cue |
+| `false` | `N` seconds | Dimmer channels fade to zero over N seconds, then playback stops |
+
+> `loop` and `fadeout` are mutually exclusive — if `loop: true` is set, `fadeout` is ignored because the sequence never completes.
+
+Set `active_sequence_id` to `null` to stop playback at any time regardless of which form was used to start it.
 
 ### Ungrouped (legacy) control
 
@@ -299,10 +341,20 @@ curl -X PATCH http://localhost:8080/entities/dmx-lighting/state \
   -H "Content-Type: application/json" \
   -d '{"state": {"active_cue_id": "<cue-uuid>"}}'
 
-# Play a sequence
+# Play a sequence (plain UUID — holds last values on completion)
 curl -X PATCH http://localhost:8080/entities/dmx-lighting/state \
   -H "Content-Type: application/json" \
   -d '{"state": {"active_sequence_id": "<sequence-uuid>"}}'
+
+# Play a sequence that loops
+curl -X PATCH http://localhost:8080/entities/dmx-lighting/state \
+  -H "Content-Type: application/json" \
+  -d '{"state": {"active_sequence_id": {"id": "<sequence-uuid>", "loop": true}}}'
+
+# Play a sequence that fades out over 4 seconds when it ends
+curl -X PATCH http://localhost:8080/entities/dmx-lighting/state \
+  -H "Content-Type: application/json" \
+  -d '{"state": {"active_sequence_id": {"id": "<sequence-uuid>", "fadeout": 4.0}}}'
 
 # Stop ungrouped playback
 curl -X PATCH http://localhost:8080/entities/dmx-lighting/state \
@@ -312,17 +364,29 @@ curl -X PATCH http://localhost:8080/entities/dmx-lighting/state \
 
 ### Per-group control
 
-Use the `group_playback` field to address any group engine independently. Multiple groups can be started or stopped in a single state update:
+Use the `group_playback` field to address any group engine independently. Multiple groups can be started or stopped in a single state update. The same plain-string or control-object format applies inside each group entry:
 
 ```bash
-# Play different sequences on two groups simultaneously
+# Play different sequences on two groups simultaneously (both looping)
+curl -X PATCH http://localhost:8080/entities/dmx-lighting/state \
+  -H "Content-Type: application/json" \
+  -d '{
+    "state": {
+      "group_playback": {
+        "<group-a-uuid>": { "active_sequence_id": {"id": "<seq-uuid-A>", "loop": true} },
+        "<group-b-uuid>": { "active_sequence_id": {"id": "<seq-uuid-B>", "fadeout": 2.5} }
+      }
+    }
+  }'
+
+# Play one group with a plain UUID, another with loop
 curl -X PATCH http://localhost:8080/entities/dmx-lighting/state \
   -H "Content-Type: application/json" \
   -d '{
     "state": {
       "group_playback": {
         "<group-a-uuid>": { "active_sequence_id": "<seq-uuid-A>" },
-        "<group-b-uuid>": { "active_sequence_id": "<seq-uuid-B>" }
+        "<group-b-uuid>": { "active_sequence_id": {"id": "<seq-uuid-B>", "loop": true} }
       }
     }
   }'
@@ -494,6 +558,22 @@ All playback endpoints accept an optional `?group_id=<uuid>` query parameter to 
 ```json
 { "sequence_id": "uuid" }
 ```
+
+Optional playback parameters can be included to control loop and fade-out behavior:
+
+```json
+{ "sequence_id": "uuid", "loop": true }
+```
+
+```json
+{ "sequence_id": "uuid", "fadeout_ms": 3000.0 }
+```
+
+| Field | Type | Default | Description |
+|-------|------|---------|-------------|
+| `sequence_id` | string | required | UUID of the sequence to play |
+| `loop` | boolean | `false` | Repeat indefinitely after the final cue |
+| `fadeout_ms` | number | `null` | After the final cue, fade dimmer channels to zero over this many milliseconds, then stop |
 
 **Single-engine status response (`GET /dmx/playback/status`):**
 ```json

--- a/docs/plans/dmx-groups-layer-system-plan.md
+++ b/docs/plans/dmx-groups-layer-system-plan.md
@@ -1,0 +1,344 @@
+# DMX Groups & Layer System — Option C
+## Full Architecture & Implementation Plan
+
+**Version:** 1.0  
+**Branch:** `feature/dmx-library-and-renaming`  
+**Status:** Approved — implementation in progress
+
+---
+
+## 1. Problem Statement
+
+The current DMX playback engine is a **single global instance** (`playback_engine` in `dmx_playback_engine.py`). It tracks one active sequence at a time. This creates three problems:
+
+1. **Universe collisions** — Recalling a cue or playing a sequence always affects all fixtures in the snapshot. If two cues share fixtures (or overlap on a universe), the second recall clobbers values set by the first.
+2. **No simultaneous playback** — You cannot run an ambient sequence on wash fixtures while triggering spot cues independently.
+3. **No safety scoping** — A programming error in one sequence can accidentally write state to fixtures that belong to a different lighting area.
+
+**Option C solves this** by introducing **DMX Groups** — named scopes that each own a set of fixtures, a set of cues/sequences, and an independent playback engine. Groups run concurrently. Outputs merge via LTP (Last Takes Precedence), which is how physical DMX consoles work. A fixture can belong to at most one group; unassigned fixtures live in an implicit "ungrouped" pool compatible with the current API.
+
+---
+
+## 2. Design Principles
+
+- **Backward compatibility** — All existing API endpoints continue to work unchanged. Ungrouped fixtures/cues/sequences are first-class citizens, not deprecated.
+- **Atomic state writes** — Use PostgreSQL `jsonb_set` to merge per-key entity state updates, so two engines writing different keys on the same entity never produce torn state.
+- **LTP merge** — The last engine to write a given channel key wins. No new merge layer is needed; the database merge is the merge.
+- **One engine per group** — Each `DMXGroupEngine` instance has its own tick loop, sequence/cue state, and fade tasks. They never share mutable state.
+- **Registry pattern** — `DMXEngineRegistry` (singleton) owns all `DMXGroupEngine` instances. Routes API calls to the correct engine by `group_id`. `None` key → ungrouped legacy engine.
+
+---
+
+## 3. Database Schema
+
+### 3.1 New Table: `dmx_groups`
+
+```sql
+CREATE TABLE dmx_groups (
+    id          UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+    name        TEXT NOT NULL,
+    color       TEXT,               -- hex color for UI badge
+    sort_order  INTEGER NOT NULL DEFAULT 0,
+    metadata    JSONB NOT NULL DEFAULT '{}',
+    created_at  TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+    updated_at  TIMESTAMPTZ NOT NULL DEFAULT NOW()
+);
+```
+
+### 3.2 Foreign Key Columns Added
+
+```sql
+-- Fixtures belong to a group (optional — NULL = ungrouped)
+ALTER TABLE dmx_fixtures
+    ADD COLUMN group_id UUID REFERENCES dmx_groups(id) ON DELETE SET NULL;
+
+-- Cues belong to a group (optional — NULL = ungrouped)
+ALTER TABLE dmx_cues
+    ADD COLUMN group_id UUID REFERENCES dmx_groups(id) ON DELETE SET NULL;
+
+-- Sequences belong to a group (optional — NULL = ungrouped)
+ALTER TABLE dmx_sequences
+    ADD COLUMN group_id UUID REFERENCES dmx_groups(id) ON DELETE SET NULL;
+```
+
+**Cascade rules:**
+- `ON DELETE SET NULL` on all three — deleting a group does not cascade-delete its fixtures, cues, or sequences. They become ungrouped instead (graceful degradation).
+
+### 3.3 Snapshot Scoping
+
+When a cue is snapshotted (`POST /dmx/cues/{id}/snapshot`), only fixtures belonging to the **same group** as the cue are captured. If the cue is ungrouped, only ungrouped fixtures are captured.
+
+This is the core safety guarantee: **a group's cues can only affect its own fixtures**.
+
+---
+
+## 4. Backend Architecture
+
+### 4.1 `DMXEngineRegistry`
+
+```python
+class DMXEngineRegistry:
+    """
+    Singleton registry of per-group playback engines.
+    Key None = ungrouped (legacy) engine.
+    """
+    _engines: dict[Optional[str], DMXGroupEngine] = {}
+    _lock: asyncio.Lock
+
+    def get(self, group_id: Optional[str]) -> DMXGroupEngine: ...
+    def all_engines(self) -> list[DMXGroupEngine]: ...
+    async def shutdown_all(self) -> None: ...
+```
+
+### 4.2 `DMXGroupEngine`
+
+Identical interface to the current `DMXPlaybackEngine`:
+
+| Method | Description |
+|--------|-------------|
+| `play(sequence_id)` | Load and play a sequence scoped to this group |
+| `pause()` | Pause current sequence |
+| `resume()` | Resume paused sequence |
+| `stop()` | Stop playback |
+| `toggle_loop()` | Toggle loop on/off |
+| `fade_out(duration_ms)` | Fade dimmer channels and stop |
+| `recall_cue_fade(from, to, duration_ms)` | Fade between cues |
+| `.status` | Current playback state dict |
+
+**Key difference from current engine:** `_batch_update` uses `jsonb_set` merge semantics instead of full state replacement:
+
+```sql
+UPDATE entities
+SET state = state || CAST(:patch AS jsonb),
+    state_updated_at = NOW()
+WHERE id = CAST(:id AS uuid)
+```
+
+This means two group engines writing *different* keys on the same entity do not interfere. Writing the same key is fine — LTP means the last write wins, which is correct DMX behavior.
+
+### 4.3 Status API Changes
+
+`GET /dmx/playback/status` currently returns a single engine's status. After migration:
+
+```json
+{
+  "engines": [
+    { "group_id": null,  "group_name": "Ungrouped", "sequence_id": "...", "play_state": "playing", ... },
+    { "group_id": "abc", "group_name": "Washes",    "sequence_id": null,  "play_state": "stopped", ... }
+  ]
+}
+```
+
+All existing playback action endpoints (`/play`, `/pause`, etc.) gain an optional `group_id` query parameter. If omitted, they target the ungrouped engine (backward compatible).
+
+### 4.4 Snapshot Scoping (Backend)
+
+`POST /dmx/cues/{id}/snapshot` currently captures all fixtures with linked entities. After migration:
+
+```sql
+SELECT f.id, f.entity_id, f.channel_map, e.state
+FROM dmx_fixtures f
+JOIN entities e ON e.id = f.entity_id
+WHERE f.group_id IS NOT DISTINCT FROM :cue_group_id   -- NULL = NULL match
+```
+
+Ungrouped cues only capture ungrouped fixtures. Group cues only capture their group's fixtures.
+
+---
+
+## 5. API Endpoints
+
+### 5.1 New Group CRUD
+
+| Method | Path | Description |
+|--------|------|-------------|
+| `GET` | `/dmx/groups` | List all groups |
+| `POST` | `/dmx/groups` | Create group |
+| `GET` | `/dmx/groups/{id}` | Get group + member summary |
+| `PATCH` | `/dmx/groups/{id}` | Update name/color/sort_order |
+| `DELETE` | `/dmx/groups/{id}` | Delete group (fixtures/cues/sequences become ungrouped) |
+
+### 5.2 Fixture Assignment
+
+| Method | Path | Description |
+|--------|------|-------------|
+| `PATCH` | `/dmx/fixtures/{id}` | Updated to accept `group_id` (null to ungroup) |
+| `POST` | `/dmx/groups/{id}/fixtures` | Bulk assign fixtures to group |
+
+### 5.3 Playback Routing
+
+All existing playback endpoints gain optional `?group_id=<uuid>` parameter. Examples:
+
+```
+POST /dmx/playback/play?group_id=abc123     → play on group "abc123" engine
+POST /dmx/playback/play                     → play on ungrouped engine (legacy)
+GET  /dmx/playback/status                   → returns all engines
+```
+
+---
+
+## 6. Frontend Architecture
+
+### 6.1 New Types (`src/lib/types.ts`)
+
+```typescript
+export interface DMXGroup {
+  id: string
+  name: string
+  color?: string
+  sort_order: number
+  metadata: Record<string, unknown>
+  created_at: string
+  updated_at: string
+}
+
+// Updated
+export interface DMXFixture {
+  // ... existing fields ...
+  group_id?: string
+}
+export interface DMXCue {
+  // ... existing fields ...
+  group_id?: string
+}
+export interface DMXSequence {
+  // ... existing fields ...
+  group_id?: string
+}
+```
+
+### 6.2 Hooks
+
+- **`useDMXGroups()`** — Fetches and manages group list, exposes create/update/delete mutations
+- **`useGroupPlayback(groupId: string | null)`** — Wraps existing `usePlayback` with group routing
+
+### 6.3 Sidebar Refactor
+
+The DMX sidebar currently shows a flat list of cues and sequences. After migration it shows groups as collapsible sections:
+
+```
+[+] Add Group
+
+▼ Washes  ●──────────────
+   Cues:   [Sunrise] [Sunset]
+   Seqs:   [▶ Morning Loop]
+
+▼ Spots  ●──────────────
+   Cues:   [Beam 1] [Beam 2]
+   Seqs:   [▶ Strobe]
+
+▼ Ungrouped
+   Cues:   [Test Cue]
+```
+
+Each group section has its own playback transport controls (play/stop/pause/loop).
+
+### 6.4 `DMXGroupRow` Component
+
+A collapsible group section header showing:
+- Color dot badge
+- Group name
+- Compact transport controls
+- Cue/sequence count badge
+- Expand/collapse toggle
+
+### 6.5 Canvas Group Indicators
+
+Each `FixtureNode` on the canvas gets a small color dot in the corner matching its group color. Ungrouped fixtures show no dot.
+
+### 6.6 Fixture Assignment in `AddFixtureModal`
+
+A group selector dropdown is added to the fixture form. Defaults to "Ungrouped". Shows group color badges.
+
+---
+
+## 7. Implementation Phases
+
+### Phase 1 — Database (migration `018_dmx_groups.sql`)
+
+- [ ] Create `dmx_groups` table
+- [ ] Add `group_id` to `dmx_fixtures`, `dmx_cues`, `dmx_sequences`
+- [ ] Add `ON DELETE SET NULL` foreign keys
+- [ ] Add indexes on `group_id` columns
+
+### Phase 2 — Backend API
+
+- [ ] Group CRUD endpoints in `dmx_router.py`
+- [ ] Update `list_fixtures`, `list_cues`, `list_sequences` to include `group_id`
+- [ ] `DMXFixtureCreate/Update` models get optional `group_id`
+- [ ] Update cue snapshot to scope by group
+- [ ] Bulk fixture assignment endpoint
+
+### Phase 3 — Playback Engine Refactor
+
+- [ ] Extract `DMXGroupEngine` from current `DMXPlaybackEngine` (minimal changes — same logic, new name)
+- [ ] Add `jsonb_set` merge semantics to `_batch_update`
+- [ ] Implement `DMXEngineRegistry` singleton
+- [ ] Update all playback endpoints to accept optional `group_id`
+- [ ] Update status endpoint to return all engines
+- [ ] Update `main.py` startup/shutdown to use registry
+
+### Phase 4 — Frontend Types & API Client
+
+- [ ] Add `DMXGroup` type, update fixture/cue/sequence types with `group_id`
+- [ ] Add group CRUD methods to `dmxApi`
+- [ ] Update playback API methods to accept optional `groupId`
+- [ ] `useDMXGroups` hook
+- [ ] `useGroupPlayback` hook wrapper
+
+### Phase 5 — Frontend UI
+
+- [ ] `DMXGroupRow` component (collapsible section, transport controls)
+- [ ] Sidebar refactor: group sections replace flat cue/sequence lists
+- [ ] `AddFixtureModal`: group selector dropdown
+- [ ] `FixtureNode` canvas: group color dot indicator
+- [ ] Group management UI (create/rename/delete/reorder)
+
+---
+
+## 8. Migration & Backward Compatibility
+
+- All existing fixtures, cues, and sequences start with `group_id = NULL` (ungrouped)
+- All existing API calls that omit `group_id` continue to work exactly as before
+- The ungrouped engine (`None` key in registry) replaces the current global singleton with zero behavior change
+- Snapshot scoping: ungrouped cues continue to capture all ungrouped fixtures (same as current behavior)
+- `GET /dmx/playback/status` old format is preserved as `engines[0]` for the ungrouped engine; clients that read the first engine's status see no change
+
+---
+
+## 9. Key Files
+
+| File | Change |
+|------|--------|
+| `config/postgres/migrations/018_dmx_groups.sql` | New — groups schema |
+| `services/fleet-manager/dmx_router.py` | Group CRUD, `group_id` on fixtures/cues/sequences, snapshot scoping, playback routing |
+| `services/fleet-manager/dmx_playback_engine.py` | Rename to `DMXGroupEngine`, add `DMXEngineRegistry`, switch to `jsonb_set` merge |
+| `services/dashboard/src/lib/types.ts` | `DMXGroup`, `group_id` fields |
+| `services/dashboard/src/lib/dmxApi.ts` | Group CRUD, `groupId` params |
+| `services/dashboard/src/hooks/useDMXGroups.ts` | New hook |
+| `services/dashboard/src/hooks/useGroupPlayback.ts` | New hook |
+| `services/dashboard/src/components/dmx/DMXGroupRow.tsx` | New component |
+| `services/dashboard/src/components/dmx/DMXSidebar.tsx` | Group-sectioned layout |
+| `services/dashboard/src/components/dmx/AddFixtureModal.tsx` | Group selector |
+| `services/dashboard/src/components/dmx/FixtureNode.tsx` | Group color dot |
+
+---
+
+## 10. LTP Semantics Example
+
+Suppose two groups are running simultaneously:
+
+| Group | Fixture | Channel | Value |
+|-------|---------|---------|-------|
+| Washes | par-01 | `intensity` | 0.8 |
+| Spots | par-01 | `color_r` | 1.0 |
+
+With `jsonb_set` merge, the entity state becomes:
+
+```json
+{ "intensity": 0.8, "color_r": 1.0 }
+```
+
+Both engines write their own keys atomically. Neither overwrites the other's channels. This is correct LTP behavior — the last write on any given channel wins.
+
+If both groups write `intensity` simultaneously, the last DB write wins. At 50 Hz tick rates this produces a ~20 ms flicker window, which is imperceptible. True HTP (Highest Takes Precedence) is out of scope for this iteration.

--- a/services/dashboard/Dockerfile
+++ b/services/dashboard/Dockerfile
@@ -1,10 +1,11 @@
 FROM node:20-alpine
 
-WORKDIR /app
-
-# Install dependencies
+# Install deps into /deps — outside the /app bind mount zone
+WORKDIR /deps
 COPY package.json package-lock.json* ./
 RUN npm ci
+
+WORKDIR /app
 
 # Copy source (will be overwritten by volume mount in dev)
 COPY . .
@@ -16,6 +17,8 @@ EXPOSE 3000
 
 ENV PORT=3000
 ENV HOSTNAME="0.0.0.0"
+# Point Node to the isolated node_modules
+ENV NODE_PATH=/deps/node_modules
+ENV PATH=/deps/node_modules/.bin:$PATH
 
-# Run in development mode (supports hot reload with volume mounts)
 CMD ["npm", "run", "dev"]

--- a/services/dashboard/src/app/dmx/page.tsx
+++ b/services/dashboard/src/app/dmx/page.tsx
@@ -47,7 +47,12 @@ function getInitialScale(): number {
 
 export default function DMXPage() {
   const { nodes, fixtures, loading, error, createNode, updateNode, deleteNode, createFixture, updateFixture, deleteFixture, bulkUpdatePositions, reorderNodes, reorderFixtures } = useDMX()
-  const { groups } = useDMXGroups()
+  const { groups, createGroup, updateGroup, deleteGroup } = useDMXGroups()
+  const [selectedGroupId, setSelectedGroupId] = useState<string | null>(null)
+  const [cueGroupId, setCueGroupId] = useState<string | null>(null)
+  // Canvas shows group highlight from whichever context is active;
+  // shift-click editing only enabled when selectedGroupId is set (Groups tab)
+  const effectiveCanvasGroupId = selectedGroupId ?? cueGroupId
   const [selectedIds, setSelectedIds] = useState<Set<string>>(new Set())
   const [showDMXAdjust, setShowDMXAdjust] = useState(false)
   const [showAddNode, setShowAddNode] = useState(false)
@@ -71,7 +76,7 @@ export default function DMXPage() {
   const [sequences, setSequences] = useState<DMXSequence[]>([])
   const [deleteSequenceTarget, setDeleteSequenceTarget] = useState<DMXSequence | null>(null)
   const [openSequencesSignal, setOpenSequencesSignal] = useState(0)
-  const { status: playbackStatus, play: playSequence, pause: pauseSequence, resume: resumeSequence, stop: stopSequence, toggleLoop, fadeOut, startPolling: startPlaybackPolling } = useSequencePlayback()
+  const { getGroupStatus, activeGroupIds, play: playSequence, pause: pauseSequence, resume: resumeSequence, stop: stopSequence, toggleLoop, fadeOut, startPolling: startPlaybackPolling } = useSequencePlayback()
   const { fadeProgress: cueFadeProgress, fadeTo: fadeCueTo, cancelFade: cancelCueFade, trackExternalFade } = useCueFade()
 
   // Real-time sync: subscribe to dmx-lighting entity state changes for external control
@@ -163,18 +168,17 @@ export default function DMXPage() {
     // while a sequence or cue is already running (WebSocket events may not fire
     // during the hold phase between cue transitions)
     Promise.all([
-      playbackApi.getStatus().catch(() => null),
+      playbackApi.getAllStatuses().catch(() => null),
       entitiesApi.getBySlug('dmx-lighting').catch(() => null),
-    ]).then(([status, entity]) => {
-      if (status && (status.play_state !== 'stopped' || status.phase !== 'idle')) {
-        startPlaybackPolling()
-      }
+    ]).then(([allStatuses, entity]) => {
+      const anyActive = allStatuses?.engines.some(
+        (e) => e.play_state !== 'stopped' || e.phase !== 'idle',
+      )
+      if (anyActive) startPlaybackPolling()
       if (entity?.state) {
         const s = entity.state as Record<string, unknown>
         const cueId = (s.active_cue_id as string | null) ?? null
-        if (cueId && (!status || status.play_state === 'stopped')) {
-          setActiveCueId(cueId)
-        }
+        if (cueId && !anyActive) setActiveCueId(cueId)
       }
     })
   // eslint-disable-next-line react-hooks/exhaustive-deps
@@ -184,6 +188,18 @@ export default function DMXPage() {
     setNodeDiameter(diameter)
     localStorage.setItem('dmx-node-scale', String(diameter))
   }
+
+  const handleToggleFixtureGroup = useCallback(async (fixtureId: string) => {
+    if (!selectedGroupId) return
+    const fixture = fixtures.find((f) => f.id === fixtureId)
+    if (!fixture) return
+    const newGroupId = fixture.group_id === selectedGroupId ? null : selectedGroupId
+    try {
+      await updateFixture(fixtureId, { group_id: newGroupId })
+    } catch {
+      // non-critical, fixture list will still reflect DB state on next refresh
+    }
+  }, [selectedGroupId, fixtures, updateFixture])
 
   const handleTogglePause = async () => {
     setPauseLoading(true)
@@ -222,6 +238,11 @@ export default function DMXPage() {
     // If we're editing a different cue, exit that edit mode
     if (editingCueId && editingCueId !== id) setEditingCueId(null)
     setActiveCueId(id)
+    // Auto-resume output — cue recall is an intentional "fire" action,
+    // not an edit operation. Gateway filters engine writes while paused.
+    if (isPaused) {
+      try { await dmxApi.resumeOutput(); setIsPaused(false) } catch { /* non-critical */ }
+    }
     try {
       await fadeCueTo(activeCueId, id, fadeDuration * 1000)
     } catch {
@@ -284,13 +305,13 @@ export default function DMXPage() {
 
   // ── Sequence handlers ──────────────────────────────────────────────────────
 
-  const handleCreateSequence = async () => {
+  const handleCreateSequence = async (groupId?: string) => {
     const names = sequences.map((s) => s.name)
     let base = 'New Sequence'; let n = 1
     while (names.includes(n === 1 ? base : `${base} ${n}`)) n++
     const name = n === 1 ? base : `${base} ${n}`
     try {
-      const seq = await dmxApi.createSequence(name)
+      const seq = await dmxApi.createSequence(name, groupId)
       setSequences((prev) => [...prev, seq])
       setOpenSequencesSignal((s) => s + 1)
     } catch (err) { console.error('Failed to create sequence:', err) }
@@ -305,9 +326,11 @@ export default function DMXPage() {
 
   const handleDeleteSequence = async (id: string) => {
     try {
+      const seq = sequences.find((s) => s.id === id)
+      const groupId = seq?.group_id ?? null
       await dmxApi.deleteSequence(id)
       setSequences((prev) => prev.filter((s) => s.id !== id))
-      if (playbackStatus.sequenceId === id) stopSequence()
+      if (getGroupStatus(groupId).sequenceId === id) await stopSequence(groupId)
       setDeleteSequenceTarget(null)
     } catch { /* silently ignore */ }
   }
@@ -366,8 +389,9 @@ export default function DMXPage() {
   }
 
   const handlePlaySequence = (seq: DMXSequence) => {
-    if (playbackStatus.sequenceId === seq.id && playbackStatus.playState === 'paused') {
-      resumeSequence()
+    const groupStatus = getGroupStatus(seq.group_id ?? null)
+    if (groupStatus.sequenceId === seq.id && groupStatus.playState === 'paused') {
+      resumeSequence(seq.group_id ?? null)
     } else {
       playSequence(seq)
     }
@@ -565,6 +589,8 @@ export default function DMXPage() {
             nodeSize={nodeDiameter}
             selectedIds={selectedIds}
             multiSelectGroup={multiSelectGroup}
+            selectedGroupId={effectiveCanvasGroupId}
+            onToggleFixtureGroup={selectedGroupId ? handleToggleFixtureGroup : undefined}
             onSelect={handleSelect}
             onEdit={(fixture) => setEditingFixture(fixture)}
             onDelete={handleDeleteRequest}
@@ -582,6 +608,13 @@ export default function DMXPage() {
           nodes={nodes}
           fixtures={fixtures}
           groups={groups}
+          selectedGroupId={selectedGroupId}
+          onGroupSelect={setSelectedGroupId}
+          cueGroupId={cueGroupId}
+          onCueGroupChange={setCueGroupId}
+          onCreateGroup={async (name, color) => { await createGroup({ name, color }) }}
+          onUpdateGroup={async (id, name, color) => { await updateGroup(id, { name, color }) }}
+          onDeleteGroup={async (id) => { await deleteGroup(id) }}
           selectedIds={selectedIds}
           multiSelectGroup={multiSelectGroup}
           onSelect={handleSelect}
@@ -605,16 +638,17 @@ export default function DMXPage() {
           onDeleteCue={handleDeleteCue}
           onReorderCues={handleReorderCues}
           onOpenCues={() => dmxApi.listCues().then(setCues).catch(() => {})}
-          onSaveCue={async (name) => { const cue = await dmxApi.saveCue(name); setCues((prev) => [cue, ...prev]) }}
+          onSaveCue={async (name, groupId) => { const cue = await dmxApi.saveCue(name, groupId); setCues((prev) => [cue, ...prev]) }}
           onUpdateCue={handleUpdateCue}
           updateCueLoading={updateCueLoading}
           sequences={sequences}
-          playbackStatus={playbackStatus}
+          getStatusForSeq={(seq) => getGroupStatus(seq.group_id ?? null)}
+          activeGroupIds={activeGroupIds}
           onPlaySequence={handlePlaySequence}
-          onPauseSequence={pauseSequence}
-          onStopSequence={stopSequence}
-          onToggleLoop={toggleLoop}
-          onFadeOut={(durationSec) => fadeOut(durationSec * 1000)}
+          onPauseSequence={(seq) => pauseSequence(seq.group_id ?? null)}
+          onStopSequence={(seq) => stopSequence(seq.group_id ?? null)}
+          onToggleLoop={(seq) => toggleLoop(seq.group_id ?? null)}
+          onFadeOut={(durationSec, seq) => fadeOut(durationSec * 1000, seq.group_id ?? null)}
           onBlackout={() => playbackApi.blackout().catch(() => {})}
           onRenameSequence={handleRenameSequence}
           onDeleteSequence={handleRequestDeleteSequence}

--- a/services/dashboard/src/app/dmx/page.tsx
+++ b/services/dashboard/src/app/dmx/page.tsx
@@ -1,6 +1,6 @@
 'use client'
 
-import { useState, useEffect, useCallback, useMemo } from 'react'
+import { useState, useEffect, useCallback, useMemo, useRef } from 'react'
 import { useDMX } from '@/hooks/useDMX'
 import { useDMXGroups } from '@/hooks/useDMXGroups'
 import { DMXCanvas } from '@/components/dmx/DMXCanvas'
@@ -65,6 +65,7 @@ export default function DMXPage() {
   const [deletingFixture, setDeletingFixture] = useState<DMXFixture | null>(null)
   const [confirmDeleteNode, setConfirmDeleteNode] = useState(false)
   const [deleteNodeDevice, setDeleteNodeDevice] = useState(false)
+  const dmxEntityIdRef = useRef<string | null>(null)
   const [isPaused, setIsPaused] = useState(false)
   const [pauseLoading, setPauseLoading] = useState(false)
   const [showClearConfirm, setShowClearConfirm] = useState(false)
@@ -175,10 +176,13 @@ export default function DMXPage() {
         (e) => e.play_state !== 'stopped' || e.phase !== 'idle',
       )
       if (anyActive) startPlaybackPolling()
-      if (entity?.state) {
-        const s = entity.state as Record<string, unknown>
-        const cueId = (s.active_cue_id as string | null) ?? null
-        if (cueId && !anyActive) setActiveCueId(cueId)
+      if (entity) {
+        dmxEntityIdRef.current = entity.id
+        if (entity.state) {
+          const s = entity.state as Record<string, unknown>
+          const cueId = (s.active_cue_id as string | null) ?? null
+          if (cueId && !anyActive) setActiveCueId(cueId)
+        }
       }
     })
   // eslint-disable-next-line react-hooks/exhaustive-deps
@@ -233,6 +237,9 @@ export default function DMXPage() {
     if (activeCueId === id) {
       setActiveCueId(null)
       cancelCueFade()
+      if (dmxEntityIdRef.current) {
+        entitiesApi.updateState(dmxEntityIdRef.current, { state: { active_cue_id: null } }).catch(() => {})
+      }
       return
     }
     // If we're editing a different cue, exit that edit mode

--- a/services/dashboard/src/app/dmx/page.tsx
+++ b/services/dashboard/src/app/dmx/page.tsx
@@ -2,6 +2,7 @@
 
 import { useState, useEffect, useCallback, useMemo } from 'react'
 import { useDMX } from '@/hooks/useDMX'
+import { useDMXGroups } from '@/hooks/useDMXGroups'
 import { DMXCanvas } from '@/components/dmx/DMXCanvas'
 import { DMXSidebar } from '@/components/dmx/DMXSidebar'
 import { NodeSetupForm } from '@/components/dmx/NodeSetupForm'
@@ -46,6 +47,7 @@ function getInitialScale(): number {
 
 export default function DMXPage() {
   const { nodes, fixtures, loading, error, createNode, updateNode, deleteNode, createFixture, updateFixture, deleteFixture, bulkUpdatePositions, reorderNodes, reorderFixtures } = useDMX()
+  const { groups } = useDMXGroups()
   const [selectedIds, setSelectedIds] = useState<Set<string>>(new Set())
   const [showDMXAdjust, setShowDMXAdjust] = useState(false)
   const [showAddNode, setShowAddNode] = useState(false)
@@ -559,6 +561,7 @@ export default function DMXPage() {
           <DMXCanvas
             fixtures={fixtures}
             nodes={nodes}
+            groups={groups}
             nodeSize={nodeDiameter}
             selectedIds={selectedIds}
             multiSelectGroup={multiSelectGroup}
@@ -578,6 +581,7 @@ export default function DMXPage() {
         <DMXSidebar
           nodes={nodes}
           fixtures={fixtures}
+          groups={groups}
           selectedIds={selectedIds}
           multiSelectGroup={multiSelectGroup}
           onSelect={handleSelect}
@@ -780,6 +784,7 @@ export default function DMXPage() {
         <AddFixtureModal
           nodes={nodes}
           fixtures={fixtures}
+          groups={groups}
           defaultPosition={{ x: 300 + fixtures.length * 30, y: 200 + fixtures.length * 20 }}
           onSubmit={createFixture}
           onClose={() => setShowAddFixture(false)}
@@ -791,6 +796,7 @@ export default function DMXPage() {
         <AddFixtureModal
           nodes={nodes}
           fixtures={fixtures}
+          groups={groups}
           fixture={editingFixture}
           onSubmit={async (data) => {
             await updateFixture(editingFixture.id, data)

--- a/services/dashboard/src/app/dmx/page.tsx
+++ b/services/dashboard/src/app/dmx/page.tsx
@@ -51,7 +51,6 @@ export default function DMXPage() {
   const [showAddNode, setShowAddNode] = useState(false)
   const [showAddFixture, setShowAddFixture] = useState(false)
   const [editingFixture, setEditingFixture] = useState<DMXFixture | null>(null)
-  const [copyingFixture, setCopyingFixture] = useState<{ fixture: DMXFixture; name: string } | null>(null)
   const [nodeDiameter, setNodeDiameter] = useState<number>(getInitialScale)
   const [editingNode, setEditingNode] = useState<DMXNode | null>(null)
   const [actionError, setActionError] = useState<string | null>(null)
@@ -395,13 +394,6 @@ export default function DMXPage() {
     }
   }
 
-  const handleCopy = (fixture: DMXFixture) => {
-    const existingNames = fixtures.map((f) => f.name)
-    const base = fixture.name.replace(/ \d+$/, '')
-    let n = 2
-    while (existingNames.includes(`${base} ${n}`)) n++
-    setCopyingFixture({ fixture, name: `${base} ${n}` })
-  }
 
   const handleDeleteRequest = (id: string) => {
     const fixture = fixtures.find((f) => f.id === id)
@@ -572,7 +564,6 @@ export default function DMXPage() {
             multiSelectGroup={multiSelectGroup}
             onSelect={handleSelect}
             onEdit={(fixture) => setEditingFixture(fixture)}
-            onCopy={handleCopy}
             onDelete={handleDeleteRequest}
             onAdjustDMX={() => setShowDMXAdjust(true)}
             onPositionsChange={async (positions) => {
@@ -809,20 +800,6 @@ export default function DMXPage() {
         />
       )}
 
-      {/* Copy Fixture Modal */}
-      {copyingFixture && (
-        <AddFixtureModal
-          nodes={nodes}
-          fixtures={fixtures}
-          copyOf={copyingFixture.fixture}
-          initialName={copyingFixture.name}
-          onSubmit={async (data) => {
-            await createFixture(data)
-            setCopyingFixture(null)
-          }}
-          onClose={() => setCopyingFixture(null)}
-        />
-      )}
 
       {/* Delete Fixture Confirmation */}
       {deletingFixture && (

--- a/services/dashboard/src/components/dmx/AddFixtureModal.tsx
+++ b/services/dashboard/src/components/dmx/AddFixtureModal.tsx
@@ -42,6 +42,14 @@ function sanitizeName(raw: string): string {
     .replace(/^_+|_+$/g, '')
 }
 
+/** Derive a URL-safe entity slug from a fixture name */
+function slugify(raw: string): string {
+  return raw
+    .toLowerCase()
+    .replace(/[^a-z0-9]+/g, '-')
+    .replace(/^-+|-+$/g, '')
+}
+
 export function AddFixtureModal({ nodes, fixtures, fixture, copyOf, initialName, defaultPosition, onSubmit, onClose }: AddFixtureModalProps) {
   const isEditing = !!fixture
   const isCopying = !!copyOf
@@ -51,6 +59,10 @@ export function AddFixtureModal({ nodes, fixtures, fixture, copyOf, initialName,
   const [error, setError] = useState<string | null>(null)
 
   const [name, setName] = useState(initialName ?? source?.name ?? '')
+  const [entitySlug, setEntitySlug] = useState(
+    isEditing ? (fixture?.entity_slug ?? '') : slugify(initialName ?? source?.name ?? '')
+  )
+  const [slugManuallyEdited, setSlugManuallyEdited] = useState(isEditing)
   const [label, setLabel] = useState(source?.label ?? '')
   const [fixtureMode, setFixtureMode] = useState(source?.fixture_mode ?? '')
   const initialNodeId = source?.node_id ?? nodes[0]?.id ?? ''
@@ -108,6 +120,13 @@ export function AddFixtureModal({ nodes, fixtures, fixture, copyOf, initialName,
       setEntityTypes(types)
     }).catch(() => {})
   }, [])
+
+  // Auto-derive slug from name while user hasn't manually edited it
+  useEffect(() => {
+    if (!slugManuallyEdited && !isEditing) {
+      setEntitySlug(slugify(name))
+    }
+  }, [name, slugManuallyEdited, isEditing])
 
   // Re-suggest start channel when node or universe changes (add/copy only).
   // Preserves the current channel span (end - start + 1) and shifts both fields to a new gap.
@@ -277,6 +296,11 @@ export function AddFixtureModal({ nodes, fixtures, fixture, copyOf, initialName,
     if (isNaN(ec) || ec < 1 || ec > 512) { setError('End channel must be 1–512'); return }
     if (ec < sc) { setError('End channel must be ≥ start channel'); return }
     const cc = ec - sc + 1
+    const trimmedSlug = entitySlug.trim()
+    if (trimmedSlug && !/^[a-z0-9][a-z0-9-]*$/.test(trimmedSlug)) {
+      setError('Slug must be lowercase letters, numbers, and hyphens only')
+      return
+    }
 
     setSubmitting(true)
     setError(null)
@@ -292,6 +316,7 @@ export function AddFixtureModal({ nodes, fixtures, fixture, copyOf, initialName,
             const created = await entitiesApi.create({
               name: name.trim(),
               entity_type_id: typeId,
+              slug: trimmedSlug || undefined,
               description: `DMX fixture — ${selectedOFLFixture ? `${selectedMfr?.name ?? ''} ${selectedOFLFixture.name}`.trim() : name.trim() || 'linked fixture'}`,
               metadata: { dmx_fixture: true },
             })
@@ -343,6 +368,7 @@ export function AddFixtureModal({ nodes, fixtures, fixture, copyOf, initialName,
         start_channel: sc,
         channel_count: cc,
         entity_id: resolvedEntityId,
+        entity_slug: isEditing && trimmedSlug && trimmedSlug !== fixture?.entity_slug ? trimmedSlug : undefined,
         ofl_fixture_id: oflFixtureId ?? (isEditing ? fixture?.ofl_fixture_id : undefined),
         channel_map: editChannelMap,
         position_x: (isCopying ? (copyOf!.position_x + 40) : fixture?.position_x) ?? defaultPosition?.x ?? 200,
@@ -547,6 +573,21 @@ export function AddFixtureModal({ nodes, fixtures, fixture, copyOf, initialName,
                   className="w-full bg-slate-800 border border-slate-700 rounded-lg px-3 py-2 text-sm text-white placeholder-slate-600 focus:outline-none focus:border-blue-500"
                   required
                   autoFocus={isEditing}
+                />
+              </div>
+              <div className="col-span-2">
+                <label className="block text-xs text-slate-400 mb-1">
+                  Entity Slug
+                  <span className="ml-2 text-slate-600 font-normal">used as the linked entity identifier</span>
+                </label>
+                <input
+                  value={entitySlug}
+                  onChange={(e) => {
+                    setEntitySlug(e.target.value)
+                    setSlugManuallyEdited(true)
+                  }}
+                  placeholder="e.g. front-wash-left"
+                  className="w-full bg-slate-800 border border-slate-700 rounded-lg px-3 py-2 text-sm text-white placeholder-slate-600 focus:outline-none focus:border-blue-500 font-mono"
                 />
               </div>
               <div>

--- a/services/dashboard/src/components/dmx/AddFixtureModal.tsx
+++ b/services/dashboard/src/components/dmx/AddFixtureModal.tsx
@@ -1,13 +1,14 @@
 'use client'
 
 import { useState, useEffect, useRef, useCallback } from 'react'
-import { DMXNode, DMXFixture, DMXFixtureCreate, ChannelMapping, Entity, EntityType, OFLManufacturer, OFLFixture, OFLFixtureMode } from '@/lib/types'
+import { DMXNode, DMXFixture, DMXFixtureCreate, DMXGroup, ChannelMapping, Entity, EntityType, OFLManufacturer, OFLFixture, OFLFixtureMode } from '@/lib/types'
 import { X, Search, ChevronDown, ExternalLink } from '@/components/icons'
 import { entitiesApi, entityTypesApi, oflApi } from '@/lib/api'
 
 interface AddFixtureModalProps {
   nodes: DMXNode[]
   fixtures: DMXFixture[]      // all existing fixtures, used to suggest start channel
+  groups?: DMXGroup[]         // available groups for assignment
   fixture?: DMXFixture        // edit mode: pre-filled, saves as update
   copyOf?: DMXFixture         // copy mode: pre-filled, saves as new create
   initialName?: string        // override the initial name field (used for copy)
@@ -50,7 +51,7 @@ function slugify(raw: string): string {
     .replace(/^-+|-+$/g, '')
 }
 
-export function AddFixtureModal({ nodes, fixtures, fixture, copyOf, initialName, defaultPosition, onSubmit, onClose }: AddFixtureModalProps) {
+export function AddFixtureModal({ nodes, fixtures, groups = [], fixture, copyOf, initialName, defaultPosition, onSubmit, onClose }: AddFixtureModalProps) {
   const isEditing = !!fixture
   const isCopying = !!copyOf
   // source to pre-fill from (edit uses fixture, copy uses copyOf)
@@ -94,6 +95,8 @@ export function AddFixtureModal({ nodes, fixtures, fixture, copyOf, initialName,
 
   // Edit mode: OFL profile loaded by ID for mode dropdown
   const [editOFLFixture, setEditOFLFixture] = useState<OFLFixture | null>(null)
+
+  const [groupId, setGroupId] = useState<string>(fixture?.group_id ?? '')
 
   // Edit mode only: entity picker
   const [entityId, setEntityId] = useState(fixture?.entity_id ?? '')
@@ -370,6 +373,7 @@ export function AddFixtureModal({ nodes, fixtures, fixture, copyOf, initialName,
         entity_id: resolvedEntityId,
         entity_slug: isEditing && trimmedSlug && trimmedSlug !== fixture?.entity_slug ? trimmedSlug : undefined,
         ofl_fixture_id: oflFixtureId ?? (isEditing ? fixture?.ofl_fixture_id : undefined),
+        group_id: groupId || undefined,
         channel_map: editChannelMap,
         position_x: (isCopying ? (copyOf!.position_x + 40) : fixture?.position_x) ?? defaultPosition?.x ?? 200,
         position_y: (isCopying ? (copyOf!.position_y + 40) : fixture?.position_y) ?? defaultPosition?.y ?? 200,
@@ -590,6 +594,21 @@ export function AddFixtureModal({ nodes, fixtures, fixture, copyOf, initialName,
                   className="w-full bg-slate-800 border border-slate-700 rounded-lg px-3 py-2 text-sm text-white placeholder-slate-600 focus:outline-none focus:border-blue-500 font-mono"
                 />
               </div>
+              {groups.length > 0 && (
+                <div className="col-span-2">
+                  <label className="block text-xs text-slate-400 mb-1">Group</label>
+                  <select
+                    value={groupId}
+                    onChange={(e) => setGroupId(e.target.value)}
+                    className="w-full bg-slate-800 border border-slate-700 rounded-lg px-3 py-2 text-sm text-white focus:outline-none focus:border-blue-500"
+                  >
+                    <option value="">Ungrouped</option>
+                    {groups.map((g) => (
+                      <option key={g.id} value={g.id}>{g.name}</option>
+                    ))}
+                  </select>
+                </div>
+              )}
               <div>
                 <label className="block text-xs text-slate-400 mb-1">Short Label</label>
                 <input

--- a/services/dashboard/src/components/dmx/ContextMenu.tsx
+++ b/services/dashboard/src/components/dmx/ContextMenu.tsx
@@ -1,19 +1,18 @@
 'use client'
 
 import { useEffect, useRef } from 'react'
-import { Pencil, Trash2, Copy, SlidersHorizontal } from '@/components/icons'
+import { Pencil, Trash2, SlidersHorizontal } from '@/components/icons'
 
 interface ContextMenuProps {
   x: number
   y: number
   onEdit: () => void
-  onCopy: () => void
   onDelete: () => void
   onAdjustDMX: () => void
   onClose: () => void
 }
 
-export function ContextMenu({ x, y, onEdit, onCopy, onDelete, onAdjustDMX, onClose }: ContextMenuProps) {
+export function ContextMenu({ x, y, onEdit, onDelete, onAdjustDMX, onClose }: ContextMenuProps) {
   const ref = useRef<HTMLDivElement>(null)
 
   useEffect(() => {
@@ -61,13 +60,6 @@ export function ContextMenu({ x, y, onEdit, onCopy, onDelete, onAdjustDMX, onClo
       >
         <Pencil className="w-3.5 h-3.5 text-slate-400" />
         Edit Fixture
-      </button>
-      <button
-        onClick={(e) => { e.stopPropagation(); onCopy(); onClose() }}
-        className="w-full flex items-center gap-2.5 px-3 py-2 text-sm text-slate-200 hover:bg-slate-700 transition-colors"
-      >
-        <Copy className="w-3.5 h-3.5 text-slate-400" />
-        Copy Fixture
       </button>
       <div className="my-1 border-t border-slate-700" />
       <button

--- a/services/dashboard/src/components/dmx/DMXCanvas.tsx
+++ b/services/dashboard/src/components/dmx/DMXCanvas.tsx
@@ -1,7 +1,7 @@
 'use client'
 
 import { useState, useRef, useCallback, useMemo, useEffect } from 'react'
-import { DMXFixture, DMXNode, FixturePositionUpdate } from '@/lib/types'
+import { DMXFixture, DMXGroup, DMXNode, FixturePositionUpdate } from '@/lib/types'
 import { UNIVERSE_PALETTE } from '@/lib/dmx-constants'
 import { useDMXActivity } from '@/hooks/useDMXActivity'
 import { SlidersHorizontal } from '@/components/icons'
@@ -11,6 +11,7 @@ import { ContextMenu } from './ContextMenu'
 interface DMXCanvasProps {
   fixtures: DMXFixture[]
   nodes: DMXNode[]
+  groups: DMXGroup[]
   nodeSize: number
   selectedIds: Set<string>
   multiSelectGroup: Set<string>
@@ -36,6 +37,7 @@ function getUniverseColor(nodes: DMXNode[], fixture: DMXFixture): string {
 export function DMXCanvas({
   fixtures,
   nodes,
+  groups,
   nodeSize,
   selectedIds,
   multiSelectGroup,
@@ -243,6 +245,7 @@ export function DMXCanvas({
             fixture={displayFixture}
             diameter={nodeSize}
             universeColor={getUniverseColor(nodes, fixture)}
+            groupColor={fixture.group_id ? (groups.find((g) => g.id === fixture.group_id)?.color ?? undefined) : undefined}
             selected={selectedIds.has(fixture.id)}
             multiSelectable={multiSelectGroup.has(fixture.id) && !selectedIds.has(fixture.id)}
             dragging={dragging === fixture.id}

--- a/services/dashboard/src/components/dmx/DMXCanvas.tsx
+++ b/services/dashboard/src/components/dmx/DMXCanvas.tsx
@@ -16,7 +16,6 @@ interface DMXCanvasProps {
   multiSelectGroup: Set<string>
   onSelect: (id: string | null, shiftKey?: boolean) => void
   onEdit: (fixture: DMXFixture) => void
-  onCopy: (fixture: DMXFixture) => void
   onDelete: (id: string) => void
   onAdjustDMX: () => void
   onPositionsChange: (positions: FixturePositionUpdate[]) => void
@@ -42,7 +41,6 @@ export function DMXCanvas({
   multiSelectGroup,
   onSelect,
   onEdit,
-  onCopy,
   onDelete,
   onAdjustDMX,
   onPositionsChange,
@@ -266,10 +264,7 @@ export function DMXCanvas({
             const fixture = fixtures.find((f) => f.id === ctxMenu.fixtureId)
             if (fixture) onEdit(fixture)
           }}
-          onCopy={() => {
-            const fixture = fixtures.find((f) => f.id === ctxMenu.fixtureId)
-            if (fixture) onCopy(fixture)
-          }}
+
           onDelete={() => onDelete(ctxMenu.fixtureId)}
           onAdjustDMX={onAdjustDMX}
           onClose={() => setCtxMenu(null)}

--- a/services/dashboard/src/components/dmx/DMXCanvas.tsx
+++ b/services/dashboard/src/components/dmx/DMXCanvas.tsx
@@ -5,7 +5,7 @@ import { DMXFixture, DMXGroup, DMXNode, FixturePositionUpdate } from '@/lib/type
 import { UNIVERSE_PALETTE } from '@/lib/dmx-constants'
 import { useDMXActivity } from '@/hooks/useDMXActivity'
 import { SlidersHorizontal } from '@/components/icons'
-import { FixtureNode } from './FixtureNode'
+import { FixtureNode, GroupMode } from './FixtureNode'
 import { ContextMenu } from './ContextMenu'
 
 interface DMXCanvasProps {
@@ -15,6 +15,8 @@ interface DMXCanvasProps {
   nodeSize: number
   selectedIds: Set<string>
   multiSelectGroup: Set<string>
+  selectedGroupId?: string | null
+  onToggleFixtureGroup?: (fixtureId: string) => void
   onSelect: (id: string | null, shiftKey?: boolean) => void
   onEdit: (fixture: DMXFixture) => void
   onDelete: (id: string) => void
@@ -41,6 +43,8 @@ export function DMXCanvas({
   nodeSize,
   selectedIds,
   multiSelectGroup,
+  selectedGroupId,
+  onToggleFixtureGroup,
   onSelect,
   onEdit,
   onDelete,
@@ -239,20 +243,36 @@ export function DMXCanvas({
       {fixtures.map((fixture) => {
         const pos = getPos(fixture)
         const displayFixture = { ...fixture, position_x: pos.x, position_y: pos.y }
+        const groupColor = fixture.group_id ? (groups.find((g) => g.id === fixture.group_id)?.color ?? undefined) : undefined
+
+        let groupMode: GroupMode | undefined
+        if (selectedGroupId) {
+          if (fixture.group_id === selectedGroupId) groupMode = 'in-group'
+          else if (!fixture.group_id) groupMode = 'eligible'
+          else groupMode = 'ineligible'
+        }
+
         return (
           <FixtureNode
             key={fixture.id}
             fixture={displayFixture}
             diameter={nodeSize}
             universeColor={getUniverseColor(nodes, fixture)}
-            groupColor={fixture.group_id ? (groups.find((g) => g.id === fixture.group_id)?.color ?? undefined) : undefined}
+            groupColor={groupColor}
+            groupMode={groupMode}
             selected={selectedIds.has(fixture.id)}
             multiSelectable={multiSelectGroup.has(fixture.id) && !selectedIds.has(fixture.id)}
             dragging={dragging === fixture.id}
             isActive={!!fixture.entity_id && activeEntityIds.has(fixture.entity_id)}
             onMouseDown={(e) => handleMouseDown(e, fixture.id)}
             onContextMenu={(e) => handleContextMenu(e, fixture.id)}
-            onClick={(shiftKey) => onSelect(fixture.id, shiftKey)}
+            onClick={(shiftKey) => {
+              if (shiftKey && selectedGroupId && onToggleFixtureGroup) {
+                if (groupMode !== 'ineligible') onToggleFixtureGroup(fixture.id)
+              } else {
+                onSelect(fixture.id, shiftKey)
+              }
+            }}
             onDoubleClick={() => { onSelect(fixture.id, false); onAdjustDMX() }}
           />
         )

--- a/services/dashboard/src/components/dmx/DMXSidebar.tsx
+++ b/services/dashboard/src/components/dmx/DMXSidebar.tsx
@@ -7,7 +7,7 @@ import { UNIVERSE_PALETTE } from '@/lib/dmx-constants'
 import { SequencePlaybackStatus } from '@/hooks/useSequencePlayback'
 import {
   Pencil, Network, Layers, SlidersHorizontal, ChevronRight, BookOpen, Trash2,
-  GripVertical, X, Check, Play, Pause, Square, ListOrdered, Plus, Repeat, Sunset, ExternalLink, ZapOff,
+  GripVertical, X, Check, Play, Pause, Square, ListOrdered, Plus, Repeat, Sunset, ExternalLink, ZapOff, FolderOpen,
 } from '@/components/icons'
 
 function getUniverseColor(nodes: DMXNode[], fixture: DMXFixture): string {
@@ -33,6 +33,13 @@ interface DMXSidebarProps {
   nodes: DMXNode[]
   fixtures: DMXFixture[]
   groups?: DMXGroup[]
+  selectedGroupId?: string | null
+  onGroupSelect?: (id: string | null) => void
+  cueGroupId?: string | null
+  onCueGroupChange?: (id: string | null) => void
+  onCreateGroup?: (name: string, color: string) => Promise<void>
+  onUpdateGroup?: (id: string, name: string, color: string) => Promise<void>
+  onDeleteGroup?: (id: string) => Promise<void>
   selectedIds: Set<string>
   multiSelectGroup: Set<string>
   onSelect: (id: string | null, shiftKey?: boolean) => void
@@ -57,17 +64,18 @@ interface DMXSidebarProps {
   onDeleteCue: (id: string) => void
   onReorderCues: (draggedId: string, targetId: string) => void
   onOpenCues: () => void
-  onSaveCue: (name: string) => Promise<void>
+  onSaveCue: (name: string, groupId?: string) => Promise<void>
   onUpdateCue: () => void
   updateCueLoading: boolean
   // Sequences
   sequences: DMXSequence[]
-  playbackStatus: SequencePlaybackStatus
+  getStatusForSeq: (seq: DMXSequence) => SequencePlaybackStatus
+  activeGroupIds: Set<string | null>
   onPlaySequence: (seq: DMXSequence) => void
-  onPauseSequence: () => void
-  onStopSequence: () => void
-  onToggleLoop: () => void
-  onFadeOut: (durationSec: number) => void
+  onPauseSequence: (seq: DMXSequence) => void
+  onStopSequence: (seq: DMXSequence) => void
+  onToggleLoop: (seq: DMXSequence) => void
+  onFadeOut: (durationSec: number, seq: DMXSequence) => void
   onBlackout: () => void
   onRenameSequence: (id: string, name: string) => Promise<void>
   onDeleteSequence: (seq: DMXSequence) => void
@@ -79,16 +87,16 @@ interface DMXSidebarProps {
   onOpenSequences: () => void
   openSequencesSignal?: number
   availableCues: DMXCue[]
-  onCreateSequence: () => void
+  onCreateSequence: (groupId?: string) => void
 }
 
-type ActiveSection = 'nodes' | 'fixtures' | 'cues' | 'sequences'
+type ActiveSection = 'nodes' | 'fixtures' | 'groups' | 'cues' | 'sequences'
 
 export function DMXSidebar({
-  nodes, fixtures, groups = [], selectedIds, multiSelectGroup, onSelect, onEdit, onDelete, onEditNode, onAdjustDMX,
+  nodes, fixtures, groups = [], selectedGroupId, onGroupSelect, cueGroupId = null, onCueGroupChange, onCreateGroup, onUpdateGroup, onDeleteGroup, selectedIds, multiSelectGroup, onSelect, onEdit, onDelete, onEditNode, onAdjustDMX,
   isPaused, onAddNode, onAddFixture, onReorderNodes, onReorderFixtures,
   cues, activeCueId, editingCueId, cueFadeProgress, onRecallCue, onEnterEditCue, onExitEditCue, onRenameCue, onDeleteCue, onReorderCues, onOpenCues, onSaveCue, onUpdateCue, updateCueLoading,
-  sequences, playbackStatus, onPlaySequence, onPauseSequence, onStopSequence, onRenameSequence, onDeleteSequence,
+  sequences, getStatusForSeq, activeGroupIds, onPlaySequence, onPauseSequence, onStopSequence, onRenameSequence, onDeleteSequence,
   onReorderSequences, onAddCueToSequence, onReorderSequenceCues, onUpdatePlacement, onRemoveCueFromSequence,
   onOpenSequences, openSequencesSignal, availableCues, onToggleLoop, onFadeOut, onBlackout, onCreateSequence,
 }: DMXSidebarProps) {
@@ -96,24 +104,35 @@ export function DMXSidebar({
   const [active, setActive] = useState<ActiveSection>(() => {
     try {
       const saved = sessionStorage.getItem(SESSION_KEY)
-      if (saved === 'nodes' || saved === 'fixtures' || saved === 'cues' || saved === 'sequences') return saved
+      if (saved === 'nodes' || saved === 'fixtures' || saved === 'groups' || saved === 'cues' || saved === 'sequences') return saved
     } catch {}
     return 'fixtures'
   })
   const setActiveSection = (s: ActiveSection) => {
     setActive(s)
+    if (s === 'groups') {
+      // Carry cue/sequence context into the Groups tab so the same group stays highlighted
+      if (cueGroupId) onGroupSelect?.(cueGroupId)
+    } else if (s === 'fixtures' || s === 'nodes') {
+      // These tabs have no group concept — clear everything
+      onGroupSelect?.(null)
+      onCueGroupChange?.(null)
+    } else {
+      // cues / sequences: selectedGroupId no longer needed (canvas driven by cueGroupId)
+      onGroupSelect?.(null)
+    }
     try { sessionStorage.setItem(SESSION_KEY, s) } catch {}
   }
 
-  // Auto-switch to sequences if one is playing when the sidebar mounts
+  // Auto-switch to sequences if any group engine is playing when the sidebar mounts
   const didAutoSwitch = useRef(false)
   useEffect(() => {
-    if (!didAutoSwitch.current && playbackStatus.playState !== 'stopped') {
+    if (!didAutoSwitch.current && activeGroupIds.size > 0) {
       didAutoSwitch.current = true
       setActiveSection('sequences')
     }
   // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [playbackStatus.playState])
+  }, [activeGroupIds.size])
 
   // ── Node drag state ────────────────────────────────────────────────────────
   const [draggedNodeId, setDraggedNodeId] = useState<string | null>(null)
@@ -137,7 +156,7 @@ export function DMXSidebar({
     setSaveCueLoading(true)
     setSaveCueError(null)
     try {
-      await onSaveCue(newCueName.trim())
+      await onSaveCue(newCueName.trim(), cueGroupId ?? undefined)
       setShowSaveCueForm(false)
       setNewCueName('')
     } catch (e) {
@@ -177,6 +196,17 @@ export function DMXSidebar({
 
   // Inline editing of placement times
   const [editingPlacement, setEditingPlacement] = useState<{ id: string; field: 'transition_time' | 'hold_duration'; value: string } | null>(null)
+
+  // ── Group management state ─────────────────────────────────────────────────
+  const GROUP_COLORS = ['#ef4444','#f97316','#eab308','#22c55e','#14b8a6','#3b82f6','#8b5cf6','#ec4899','#94a3b8']
+  const [showNewGroupForm, setShowNewGroupForm] = useState(false)
+  const [newGroupName, setNewGroupName] = useState('')
+  const [newGroupColor, setNewGroupColor] = useState(GROUP_COLORS[0])
+  const [newGroupLoading, setNewGroupLoading] = useState(false)
+  const [renamingGroupId, setRenamingGroupId] = useState<string | null>(null)
+  const [renameGroupValue, setRenameGroupValue] = useState('')
+  const [renamingGroupColor, setRenamingGroupColor] = useState('')
+  const [groupError, setGroupError] = useState<string | null>(null)
 
   // Auto-switch to sequences section when a new sequence is added externally
   useEffect(() => {
@@ -224,10 +254,11 @@ export function DMXSidebar({
     setEditingPlacement(null)
   }
 
-  function getPlaybackPhaseForSeq(seqId: string) {
-    if (playbackStatus.sequenceId !== seqId) return null
-    if (playbackStatus.playState === 'stopped') return null
-    return { state: playbackStatus.playState, phase: playbackStatus.phase, progress: playbackStatus.progress, holdProgress: playbackStatus.holdProgress, cueIndex: playbackStatus.cueIndex }
+  function getPlaybackPhaseForSeq(seq: DMXSequence) {
+    const s = getStatusForSeq(seq)
+    if (s.sequenceId !== seq.id) return null
+    if (s.playState === 'stopped') return null
+    return { state: s.playState, phase: s.phase, progress: s.progress, holdProgress: s.holdProgress, cueIndex: s.cueIndex, loop: s.loop }
   }
 
   return (
@@ -539,6 +570,238 @@ export function DMXSidebar({
         </div>
       </div>
 
+      {/* ── Groups section ───────────────────────────────────────────── */}
+      <div className="flex flex-col shrink-0" style={{ transition: 'flex 350ms cubic-bezier(0.4,0,0.2,1)' }}>
+        <div
+          onClick={() => setActiveSection('groups')}
+          className={`flex items-center gap-2 px-4 py-3 text-left w-full transition-colors shrink-0 cursor-pointer select-none border-t border-slate-800 ${
+            active === 'groups' ? 'border-b border-slate-800' : 'hover:bg-slate-800/40'
+          }`}
+        >
+          <FolderOpen className={`w-3.5 h-3.5 transition-colors ${active === 'groups' ? 'text-slate-400' : 'text-slate-600'}`} />
+          <span className={`text-[10px] uppercase tracking-wider font-medium transition-colors ${active === 'groups' ? 'text-slate-400' : 'text-slate-600'}`}>
+            Groups
+          </span>
+          <span className={`text-[10px] transition-colors ${active === 'groups' ? 'text-slate-600' : 'text-slate-700'}`}>
+            ({groups.length})
+          </span>
+          <button
+            onClick={(e) => { e.stopPropagation(); setShowNewGroupForm(true); setActiveSection('groups') }}
+            className="ml-auto text-slate-600 hover:text-blue-400 transition-colors cursor-pointer p-0.5"
+            title="Add Group"
+          >
+            <Plus className="w-3.5 h-3.5" />
+          </button>
+          <ChevronRight className={`w-3 h-3 transition-transform duration-300 ${active === 'groups' ? 'text-slate-500 rotate-90' : 'text-slate-700'}`} />
+        </div>
+
+        <div
+          className="overflow-hidden"
+          style={{
+            display: 'grid',
+            gridTemplateRows: active === 'groups' ? '1fr' : '0fr',
+            transition: 'grid-template-rows 350ms cubic-bezier(0.4,0,0.2,1)',
+          }}
+        >
+          <div className="min-h-0 overflow-y-auto">
+            <div
+              className="px-4 py-3 space-y-2 min-h-[48px]"
+              onClick={() => { onGroupSelect?.(null); onCueGroupChange?.(null) }}
+            >
+              {groupError && (
+                <p className="text-[10px] text-red-400">{groupError}</p>
+              )}
+
+              {/* New group form */}
+              {showNewGroupForm && (
+                <div className="rounded-lg border border-slate-700 bg-slate-800/60 p-3 space-y-2">
+                  <input
+                    autoFocus
+                    type="text"
+                    value={newGroupName}
+                    onChange={(e) => setNewGroupName(e.target.value)}
+                    onKeyDown={(e) => {
+                      if (e.key === 'Escape') { setShowNewGroupForm(false); setNewGroupName('') }
+                      if (e.key === 'Enter') {
+                        e.preventDefault()
+                        if (!newGroupName.trim() || !onCreateGroup) return
+                        setNewGroupLoading(true)
+                        setGroupError(null)
+                        onCreateGroup(newGroupName.trim(), newGroupColor)
+                          .then(() => { setShowNewGroupForm(false); setNewGroupName(''); setNewGroupColor(GROUP_COLORS[0]) })
+                          .catch((err: unknown) => setGroupError(err instanceof Error ? err.message : 'Failed'))
+                          .finally(() => setNewGroupLoading(false))
+                      }
+                    }}
+                    placeholder="Group name"
+                    className="w-full bg-slate-900 border border-slate-700 rounded px-2 py-1 text-xs text-slate-200 placeholder-slate-600 focus:outline-none focus:border-slate-500"
+                  />
+                  <div className="flex flex-wrap gap-1.5">
+                    {GROUP_COLORS.map((c) => (
+                      <button
+                        key={c}
+                        onClick={() => setNewGroupColor(c)}
+                        className="w-5 h-5 rounded-full border-2 transition-all"
+                        style={{ background: c, borderColor: newGroupColor === c ? '#ffffff' : 'transparent' }}
+                      />
+                    ))}
+                  </div>
+                  <div className="flex gap-2">
+                    <button
+                      onClick={() => {
+                        if (!newGroupName.trim() || !onCreateGroup) return
+                        setNewGroupLoading(true)
+                        setGroupError(null)
+                        onCreateGroup(newGroupName.trim(), newGroupColor)
+                          .then(() => { setShowNewGroupForm(false); setNewGroupName(''); setNewGroupColor(GROUP_COLORS[0]) })
+                          .catch((err: unknown) => setGroupError(err instanceof Error ? err.message : 'Failed'))
+                          .finally(() => setNewGroupLoading(false))
+                      }}
+                      disabled={!newGroupName.trim() || newGroupLoading}
+                      className="flex-1 py-1 rounded text-[10px] font-medium bg-blue-700 hover:bg-blue-600 disabled:opacity-50 text-white transition-colors"
+                    >
+                      {newGroupLoading ? 'Creating…' : 'Create'}
+                    </button>
+                    <button
+                      onClick={() => { setShowNewGroupForm(false); setNewGroupName('') }}
+                      className="px-3 py-1 rounded text-[10px] text-slate-400 hover:text-slate-200 bg-slate-700/50 hover:bg-slate-700 transition-colors"
+                    >
+                      Cancel
+                    </button>
+                  </div>
+                </div>
+              )}
+
+              {groups.length === 0 && !showNewGroupForm ? (
+                <p className="text-xs text-slate-600">No groups yet</p>
+              ) : (
+                <div className="space-y-1.5">
+                  {/* All — clears group selection, shows full canvas */}
+                  <div
+                    onClick={(e) => { e.stopPropagation(); onGroupSelect?.(null); onCueGroupChange?.(null) }}
+                    className={`rounded-lg px-3 py-2 border transition-colors cursor-pointer select-none ${
+                      selectedGroupId === null
+                        ? 'border-slate-500 bg-slate-700/60'
+                        : 'bg-slate-800/50 border-transparent hover:border-slate-700/50'
+                    }`}
+                  >
+                    <div className="flex items-center gap-2">
+                      <span className="w-2.5 h-2.5 rounded-full shrink-0 bg-slate-600 border border-slate-500" />
+                      <span className={`text-xs flex-1 transition-colors ${selectedGroupId === null ? 'text-white' : 'text-slate-400'}`}>All</span>
+                      <span className="text-[10px] text-slate-500 shrink-0">{fixtures.length}fx</span>
+                      {selectedGroupId === null && (
+                        <span className="text-[9px] text-slate-400 shrink-0 font-mono">all</span>
+                      )}
+                    </div>
+                  </div>
+
+                  {groups.map((group) => {
+                    const fixtureCount = fixtures.filter((f) => f.group_id === group.id).length
+                    const isRenaming = renamingGroupId === group.id
+                    const isSelected = selectedGroupId === group.id
+                    return (
+                      <div
+                        key={group.id}
+                        onClick={(e) => { e.stopPropagation(); if (!isRenaming) { const next = isSelected ? null : group.id; onGroupSelect?.(next); onCueGroupChange?.(next) } }}
+                        className={`rounded-lg px-3 py-2 border transition-colors cursor-pointer select-none ${
+                          isSelected
+                            ? 'border-slate-500 bg-slate-700/60'
+                            : 'bg-slate-800/50 border-transparent hover:border-slate-700/50'
+                        }`}
+                        style={isSelected && group.color ? { borderColor: `${group.color}66`, backgroundColor: `${group.color}18` } : undefined}
+                      >
+                        {isRenaming ? (
+                          <div className="space-y-2">
+                            <input
+                              autoFocus
+                              type="text"
+                              value={renameGroupValue}
+                              onChange={(e) => setRenameGroupValue(e.target.value)}
+                              onKeyDown={(e) => {
+                                if (e.key === 'Escape') setRenamingGroupId(null)
+                                if (e.key === 'Enter') {
+                                  e.preventDefault()
+                                  if (!renameGroupValue.trim() || !onUpdateGroup) { setRenamingGroupId(null); return }
+                                  onUpdateGroup(group.id, renameGroupValue.trim(), renamingGroupColor)
+                                    .catch((err: unknown) => setGroupError(err instanceof Error ? err.message : 'Failed'))
+                                    .finally(() => setRenamingGroupId(null))
+                                }
+                              }}
+                              className="w-full bg-slate-900 border border-slate-700 rounded px-2 py-1 text-xs text-slate-200 focus:outline-none focus:border-slate-500"
+                            />
+                            <div className="flex flex-wrap gap-1.5">
+                              {GROUP_COLORS.map((c) => (
+                                <button
+                                  key={c}
+                                  onClick={() => setRenamingGroupColor(c)}
+                                  className="w-4 h-4 rounded-full border-2 transition-all"
+                                  style={{ background: c, borderColor: renamingGroupColor === c ? '#ffffff' : 'transparent' }}
+                                />
+                              ))}
+                            </div>
+                            <div className="flex gap-1.5">
+                              <button
+                                onClick={() => {
+                                  if (!renameGroupValue.trim() || !onUpdateGroup) { setRenamingGroupId(null); return }
+                                  onUpdateGroup(group.id, renameGroupValue.trim(), renamingGroupColor)
+                                    .catch((err: unknown) => setGroupError(err instanceof Error ? err.message : 'Failed'))
+                                    .finally(() => setRenamingGroupId(null))
+                                }}
+                                className="flex items-center justify-center w-6 h-6 rounded bg-blue-700 hover:bg-blue-600 transition-colors"
+                              >
+                                <Check className="w-3 h-3 text-white" />
+                              </button>
+                              <button
+                                onClick={() => setRenamingGroupId(null)}
+                                className="flex items-center justify-center w-6 h-6 rounded bg-slate-700 hover:bg-slate-600 transition-colors"
+                              >
+                                <X className="w-3 h-3 text-slate-300" />
+                              </button>
+                            </div>
+                          </div>
+                        ) : (
+                          <div className="flex items-center gap-2">
+                            <span
+                              className="w-2.5 h-2.5 rounded-full shrink-0 transition-all"
+                              style={{
+                                background: group.color ?? '#64748b',
+                                boxShadow: isSelected && group.color ? `0 0 6px ${group.color}cc` : 'none',
+                              }}
+                            />
+                            <span className={`text-xs truncate flex-1 transition-colors ${isSelected ? 'text-white' : 'text-slate-200'}`}>{group.name}</span>
+                            {activeGroupIds.has(group.id) && (
+                              <span className="w-1.5 h-1.5 rounded-full bg-green-400 animate-pulse shrink-0" title="Sequence playing" />
+                            )}
+                            <span className="text-[10px] text-slate-500 shrink-0">{fixtureCount}fx</span>
+                            {isSelected && (
+                              <span className="text-[9px] text-slate-400 shrink-0 font-mono">editing</span>
+                            )}
+                            <button
+                              onClick={(e) => { e.stopPropagation(); setRenamingGroupId(group.id); setRenameGroupValue(group.name); setRenamingGroupColor(group.color ?? GROUP_COLORS[0]) }}
+                              className="text-slate-600 hover:text-slate-300 transition-colors shrink-0"
+                              title="Rename"
+                            >
+                              <Pencil className="w-3 h-3" />
+                            </button>
+                            <button
+                              onClick={(e) => { e.stopPropagation(); onDeleteGroup?.(group.id).catch((err: unknown) => setGroupError(err instanceof Error ? err.message : 'Failed')) }}
+                              className="text-slate-700 hover:text-red-400 transition-colors shrink-0"
+                              title="Delete group"
+                            >
+                              <Trash2 className="w-3 h-3" />
+                            </button>
+                          </div>
+                        )}
+                      </div>
+                    )
+                  })}
+                </div>
+              )}
+            </div>
+          </div>
+        </div>
+      </div>
+
       {/* ── Cues section ─────────────────────────────────────────────── */}
       <div
         className="flex flex-col min-h-0"
@@ -565,6 +828,36 @@ export function DMXSidebar({
           )}
           <ChevronRight className={`w-3 h-3 ml-auto transition-transform duration-300 ${active === 'cues' ? 'text-slate-500 rotate-90' : 'text-slate-700'}`} />
         </button>
+
+        {/* Group context selector — only shown when expanded and groups exist */}
+        {active === 'cues' && groups.length > 0 && (
+          <div className="flex items-center gap-1.5 px-4 py-2 border-b border-slate-800/60 overflow-x-auto scrollbar-none shrink-0">
+            <button
+              onClick={() => onCueGroupChange?.(null)}
+              className={`shrink-0 px-2 py-0.5 rounded text-[10px] font-medium transition-colors ${
+                cueGroupId === null ? 'bg-slate-600 text-white' : 'text-slate-500 hover:text-slate-300 hover:bg-slate-800'
+              }`}
+            >
+              All
+            </button>
+            {groups.map((g) => (
+              <button
+                key={g.id}
+                onClick={() => onCueGroupChange?.(cueGroupId === g.id ? null : g.id)}
+                className={`shrink-0 flex items-center gap-1 px-2 py-0.5 rounded text-[10px] font-medium transition-colors ${
+                  cueGroupId === g.id ? 'bg-slate-700 text-white' : 'text-slate-500 hover:text-slate-300 hover:bg-slate-800'
+                }`}
+                style={cueGroupId === g.id && g.color ? { borderLeft: `2px solid ${g.color}`, paddingLeft: 6 } : undefined}
+              >
+                <span className="w-1.5 h-1.5 rounded-full shrink-0" style={{ background: g.color ?? '#64748b' }} />
+                {g.name}
+                {activeGroupIds.has(g.id) && (
+                  <span className="w-1 h-1 rounded-full bg-green-400 animate-pulse shrink-0" />
+                )}
+              </button>
+            ))}
+          </div>
+        )}
 
         <div
           className="overflow-hidden flex-1"
@@ -642,7 +935,7 @@ export function DMXSidebar({
                   )}
                 </>
               ) : (
-                <p className="text-[10px] text-slate-600">Pause signals to save cues</p>
+                <p className="text-[10px] text-slate-600">Click a cue to recall it · Pause signals to save</p>
               )}
             </div>
             {/* Fade duration setting */}
@@ -661,12 +954,18 @@ export function DMXSidebar({
                 <span className="ml-auto text-[9px] text-amber-600 font-medium uppercase tracking-wide">on</span>
               )}
             </div>
+            {(() => {
+              const visibleCues = cueGroupId === null ? cues : cues.filter((c) => (c.group_id ?? null) === cueGroupId)
+              const cueEmptyMsg = cues.length === 0
+                ? 'No cues saved yet. Pause signals and use Save Cue to capture the current state.'
+                : `No cues in ${groups.find((g) => g.id === cueGroupId)?.name ?? 'this group'} yet.`
+              return (
             <div className="px-4 py-3">
-              {cues.length === 0 ? (
-                <p className="text-xs text-slate-600">No cues saved yet. Pause signals and use Save Cue to capture the current state.</p>
+              {visibleCues.length === 0 ? (
+                <p className="text-xs text-slate-600">{cueEmptyMsg}</p>
               ) : (
                 <div className="space-y-1">
-                  {cues.map((cue) => {
+                  {visibleCues.map((cue) => {
                     const isActive = activeCueId === cue.id
                     const isEditing = editingCueId === cue.id
                     const isRenaming = renamingCueId === cue.id
@@ -806,6 +1105,8 @@ export function DMXSidebar({
                 </div>
               )}
             </div>
+              )
+            })()}
           </div>
         </div>
       </div>
@@ -831,11 +1132,11 @@ export function DMXSidebar({
           <span className={`text-[10px] transition-colors ${active === 'sequences' ? 'text-slate-600' : 'text-slate-700'}`}>
             ({sequences.length})
           </span>
-          {playbackStatus.playState !== 'stopped' && (
+          {activeGroupIds.size > 0 && (
             <span className="ml-1 w-1.5 h-1.5 rounded-full shrink-0 bg-green-400 animate-pulse" />
           )}
           <button
-            onClick={(e) => { e.stopPropagation(); onCreateSequence() }}
+            onClick={(e) => { e.stopPropagation(); onCreateSequence(cueGroupId ?? undefined) }}
             className="ml-auto text-slate-600 hover:text-blue-400 transition-colors cursor-pointer p-0.5"
             title="Add Sequence"
           >
@@ -843,6 +1144,36 @@ export function DMXSidebar({
           </button>
           <ChevronRight className={`w-3 h-3 transition-transform duration-300 ${active === 'sequences' ? 'text-slate-500 rotate-90' : 'text-slate-700'}`} />
         </div>
+
+        {/* Group context selector — shared with Cues */}
+        {active === 'sequences' && groups.length > 0 && (
+          <div className="flex items-center gap-1.5 px-4 py-2 border-b border-slate-800/60 overflow-x-auto scrollbar-none shrink-0">
+            <button
+              onClick={() => onCueGroupChange?.(null)}
+              className={`shrink-0 px-2 py-0.5 rounded text-[10px] font-medium transition-colors ${
+                cueGroupId === null ? 'bg-slate-600 text-white' : 'text-slate-500 hover:text-slate-300 hover:bg-slate-800'
+              }`}
+            >
+              All
+            </button>
+            {groups.map((g) => (
+              <button
+                key={g.id}
+                onClick={() => onCueGroupChange?.(cueGroupId === g.id ? null : g.id)}
+                className={`shrink-0 flex items-center gap-1 px-2 py-0.5 rounded text-[10px] font-medium transition-colors ${
+                  cueGroupId === g.id ? 'bg-slate-700 text-white' : 'text-slate-500 hover:text-slate-300 hover:bg-slate-800'
+                }`}
+                style={cueGroupId === g.id && g.color ? { borderLeft: `2px solid ${g.color}`, paddingLeft: 6 } : undefined}
+              >
+                <span className="w-1.5 h-1.5 rounded-full shrink-0" style={{ background: g.color ?? '#64748b' }} />
+                {g.name}
+                {activeGroupIds.has(g.id) && (
+                  <span className="w-1 h-1 rounded-full bg-green-400 animate-pulse shrink-0" />
+                )}
+              </button>
+            ))}
+          </div>
+        )}
 
         <div
           className="overflow-hidden flex-1"
@@ -869,13 +1200,19 @@ export function DMXSidebar({
                 <span className="ml-auto text-[9px] text-amber-600 font-medium uppercase tracking-wide">on</span>
               )}
             </div>
+            {(() => {
+              const visibleSeqs = cueGroupId === null ? sequences : sequences.filter((s) => (s.group_id ?? null) === cueGroupId)
+              const seqEmptyMsg = sequences.length === 0
+                ? 'No sequences yet. Click + to create one.'
+                : `No sequences in ${groups.find((g) => g.id === cueGroupId)?.name ?? 'this group'} yet.`
+              return (
             <div className="px-3 py-3">
-              {sequences.length === 0 ? (
-                <p className="text-xs text-slate-600 px-1">No sequences yet. Pause signals to create one.</p>
+              {visibleSeqs.length === 0 ? (
+                <p className="text-xs text-slate-600 px-1">{seqEmptyMsg}</p>
               ) : (
                 <div className="space-y-1.5">
-                  {sequences.map((seq) => {
-                    const pb = getPlaybackPhaseForSeq(seq.id)
+                  {visibleSeqs.map((seq) => {
+                    const pb = getPlaybackPhaseForSeq(seq)
                     const isThisPlaying = pb !== null && pb.state === 'playing'
                     const isThisPaused = pb !== null && pb.state === 'paused'
                     const isThisActive = pb !== null
@@ -997,16 +1334,16 @@ export function DMXSidebar({
                             <div className="flex items-center gap-0.5 shrink-0">
                               {/* Loop toggle */}
                               <button
-                                onClick={(e) => { e.stopPropagation(); onToggleLoop() }}
-                                title={playbackStatus.loop ? 'Loop on — click to disable' : 'Enable loop'}
-                                className={`p-0.5 rounded transition-colors ${playbackStatus.loop ? 'text-blue-400 hover:text-blue-200' : 'text-slate-600 hover:text-blue-400'}`}
+                                onClick={(e) => { e.stopPropagation(); onToggleLoop(seq) }}
+                                title={pb?.loop ? 'Loop on — click to disable' : 'Enable loop'}
+                                className={`p-0.5 rounded transition-colors ${pb?.loop ? 'text-blue-400 hover:text-blue-200' : 'text-slate-600 hover:text-blue-400'}`}
                               >
                                 <Repeat className="w-3 h-3" />
                               </button>
 
                               {/* Play / Pause toggle */}
                               <button
-                                onClick={(e) => { e.stopPropagation(); isThisPlaying ? onPauseSequence() : onPlaySequence(seq) }}
+                                onClick={(e) => { e.stopPropagation(); isThisPlaying ? onPauseSequence(seq) : onPlaySequence(seq) }}
                                 title={isThisPlaying ? 'Pause sequence' : isThisPaused ? 'Resume sequence' : 'Play sequence'}
                                 className={`p-0.5 rounded transition-colors ${isThisPlaying ? 'text-green-400 hover:text-green-200' : 'text-slate-500 hover:text-green-400'}`}
                               >
@@ -1026,14 +1363,14 @@ export function DMXSidebar({
                               {isThisActive && (
                                 <>
                                   <button
-                                    onClick={(e) => { e.stopPropagation(); onStopSequence() }}
+                                    onClick={(e) => { e.stopPropagation(); onStopSequence(seq) }}
                                     title="Stop sequence"
                                     className="p-0.5 rounded text-slate-500 hover:text-red-400 transition-colors"
                                   >
                                     <Square className="w-3 h-3" />
                                   </button>
                                   <button
-                                    onClick={(e) => { e.stopPropagation(); onFadeOut(fadeOutDuration) }}
+                                    onClick={(e) => { e.stopPropagation(); onFadeOut(fadeOutDuration, seq) }}
                                     title="Stop with 3s dimmer fadeout"
                                     className="p-0.5 rounded text-slate-500 hover:text-amber-400 transition-colors"
                                   >
@@ -1208,6 +1545,8 @@ export function DMXSidebar({
                 </div>
               )}
             </div>
+              )
+            })()}
           </div>
         </div>
       </div>
@@ -1233,15 +1572,24 @@ export function DMXSidebar({
         </div>
         <div className="max-h-56 overflow-y-auto">
           {(() => {
-            const filtered = availableCues.filter((c) =>
-              c.name.toLowerCase().includes(cueSearch.toLowerCase())
-            )
+            // Only show cues whose group matches the sequence being added to
+            const targetSeq = sequences.find((s) => s.id === showAddCueFor)
+            const targetGroupId = targetSeq?.group_id ?? null
+            const filtered = availableCues.filter((c) => {
+              const matchesGroup = (c.group_id ?? null) === targetGroupId
+              const matchesSearch = c.name.toLowerCase().includes(cueSearch.toLowerCase())
+              return matchesGroup && matchesSearch
+            })
             return filtered.length === 0 ? (
-              <p className="text-[10px] text-slate-500 px-3 py-2">No cues found</p>
+              <p className="text-[10px] text-slate-500 px-3 py-2">
+                {targetGroupId
+                  ? `No cues in ${groups.find((g) => g.id === targetGroupId)?.name ?? 'this group'}`
+                  : 'No ungrouped cues found'}
+              </p>
             ) : filtered.map((c) => (
               <button
                 key={c.id}
-                onClick={() => { onAddCueToSequence(showAddCueFor, c.id); setShowAddCueFor(null); setDropdownPos(null); setCueSearch('') }}
+                onClick={() => { onAddCueToSequence(showAddCueFor!, c.id); setShowAddCueFor(null); setDropdownPos(null); setCueSearch('') }}
                 className="w-full text-left px-3 py-1.5 text-xs text-slate-300 hover:bg-slate-700 hover:text-white transition-colors truncate"
               >
                 {c.name}

--- a/services/dashboard/src/components/dmx/DMXSidebar.tsx
+++ b/services/dashboard/src/components/dmx/DMXSidebar.tsx
@@ -473,6 +473,7 @@ export function DMXSidebar({
                                     : 'border-transparent hover:bg-slate-800/70'
                                 }`}
                                 onClick={(e) => onSelect(fixture.id, e.shiftKey)}
+                                onDoubleClick={(e) => { e.stopPropagation(); onEdit(fixture) }}
                               >
                                 {/* Row 1: grip · name · actions */}
                                 <div className="flex items-center gap-1">
@@ -767,6 +768,24 @@ export function DMXSidebar({
                             <div className={`text-[10px] mt-0.5 ${isEditing ? 'text-indigo-600' : isActive ? 'text-amber-700' : 'text-slate-600'}`}>
                               {isEditing ? 'Edit mode — adjust channels, then Update Cue' : isActive ? 'Active' : formatRelativeTime(cue.created_at)}
                             </div>
+                            {!isEditing && cue.nodes && cue.nodes.length > 0 && (
+                              <div className="flex flex-wrap gap-1 mt-1">
+                                {cue.nodes.map((n) => (
+                                  <span
+                                    key={n.node_id}
+                                    className={`inline-flex items-center gap-0.5 text-[9px] px-1.5 py-0.5 rounded font-mono ${
+                                      isActive
+                                        ? 'bg-amber-900/30 text-amber-600 border border-amber-800/40'
+                                        : 'bg-slate-800 text-slate-500 border border-slate-700/50'
+                                    }`}
+                                  >
+                                    {n.node_name}
+                                    <span className="opacity-60 mx-0.5">·</span>
+                                    U{n.universes.join(',')}
+                                  </span>
+                                ))}
+                              </div>
+                            )}
                           </>
                         )}
                         </div>{/* end px-3 py-2 */}

--- a/services/dashboard/src/components/dmx/DMXSidebar.tsx
+++ b/services/dashboard/src/components/dmx/DMXSidebar.tsx
@@ -2,7 +2,7 @@
 
 import { useState, useRef, useEffect } from 'react'
 import { createPortal } from 'react-dom'
-import { DMXFixture, DMXNode, DMXCue, DMXSequence, DMXCuePlacement } from '@/lib/types'
+import { DMXFixture, DMXGroup, DMXNode, DMXCue, DMXSequence, DMXCuePlacement } from '@/lib/types'
 import { UNIVERSE_PALETTE } from '@/lib/dmx-constants'
 import { SequencePlaybackStatus } from '@/hooks/useSequencePlayback'
 import {
@@ -32,6 +32,7 @@ function formatRelativeTime(iso: string): string {
 interface DMXSidebarProps {
   nodes: DMXNode[]
   fixtures: DMXFixture[]
+  groups?: DMXGroup[]
   selectedIds: Set<string>
   multiSelectGroup: Set<string>
   onSelect: (id: string | null, shiftKey?: boolean) => void
@@ -84,7 +85,7 @@ interface DMXSidebarProps {
 type ActiveSection = 'nodes' | 'fixtures' | 'cues' | 'sequences'
 
 export function DMXSidebar({
-  nodes, fixtures, selectedIds, multiSelectGroup, onSelect, onEdit, onDelete, onEditNode, onAdjustDMX,
+  nodes, fixtures, groups = [], selectedIds, multiSelectGroup, onSelect, onEdit, onDelete, onEditNode, onAdjustDMX,
   isPaused, onAddNode, onAddFixture, onReorderNodes, onReorderFixtures,
   cues, activeCueId, editingCueId, cueFadeProgress, onRecallCue, onEnterEditCue, onExitEditCue, onRenameCue, onDeleteCue, onReorderCues, onOpenCues, onSaveCue, onUpdateCue, updateCueLoading,
   sequences, playbackStatus, onPlaySequence, onPauseSequence, onStopSequence, onRenameSequence, onDeleteSequence,
@@ -748,6 +749,16 @@ export function DMXSidebar({
                                   {cue.name}
                                 </span>
                               )}
+                              {cue.group_id && (() => {
+                                const g = groups.find((gr) => gr.id === cue.group_id)
+                                return g?.color ? (
+                                  <span
+                                    className="w-2 h-2 rounded-full shrink-0"
+                                    style={{ background: g.color }}
+                                    title={g.name}
+                                  />
+                                ) : null
+                              })()}
                               <div className={`flex items-center gap-1 shrink-0 transition-opacity ${isEditing ? 'opacity-100' : 'opacity-0 group-hover:opacity-100'}`}>
                                 {isEditing ? (
                                   <button onClick={(e) => { e.stopPropagation(); onExitEditCue() }} title="Exit edit mode" className="text-indigo-400 hover:text-indigo-200 transition-colors">
@@ -969,6 +980,17 @@ export function DMXSidebar({
                               {seq.name}
                             </span>
                           )}
+
+                          {seq.group_id && (() => {
+                            const g = groups.find((gr) => gr.id === seq.group_id)
+                            return g?.color ? (
+                              <span
+                                className="w-2 h-2 rounded-full shrink-0"
+                                style={{ background: g.color }}
+                                title={g.name}
+                              />
+                            ) : null
+                          })()}
 
                           {/* Playback controls */}
                           {!isRenamingSeq && (

--- a/services/dashboard/src/components/dmx/FixtureNode.tsx
+++ b/services/dashboard/src/components/dmx/FixtureNode.tsx
@@ -3,11 +3,14 @@
 import { useState } from 'react'
 import { DMXFixture } from '@/lib/types'
 
+export type GroupMode = 'in-group' | 'eligible' | 'ineligible'
+
 interface FixtureNodeProps {
   fixture: DMXFixture
   diameter: number
   universeColor: string
   groupColor?: string
+  groupMode?: GroupMode
   selected: boolean
   multiSelectable: boolean
   dragging: boolean
@@ -23,6 +26,7 @@ export function FixtureNode({
   diameter,
   universeColor,
   groupColor,
+  groupMode,
   selected,
   multiSelectable,
   dragging,
@@ -43,18 +47,19 @@ export function FixtureNode({
 
   return (
     <div
-      onMouseDown={onMouseDown}
+      onMouseDown={groupMode === 'ineligible' ? undefined : onMouseDown}
       onContextMenu={onContextMenu}
       onClick={(e) => { e.stopPropagation(); onClick(e.shiftKey) }}
       onDoubleClick={(e) => { e.stopPropagation(); onDoubleClick?.() }}
       onMouseEnter={() => setHovered(true)}
       onMouseLeave={() => setHovered(false)}
-      className="absolute flex items-center select-none"
+      className="absolute flex items-center select-none transition-opacity duration-150"
       style={{
         left: fixture.position_x - radius,
         top: fixture.position_y - radius,
-        cursor: dragging ? 'grabbing' : 'grab',
+        cursor: groupMode === 'ineligible' ? 'not-allowed' : dragging ? 'grabbing' : 'grab',
         zIndex: dragging ? 100 : selected ? 50 : 10,
+        opacity: groupMode === 'ineligible' ? 0.3 : 1,
       }}
     >
       {/* Circle */}
@@ -63,25 +68,48 @@ export function FixtureNode({
         style={{
           width: diameter,
           height: diameter,
-          boxShadow: selected
+          boxShadow: groupMode === 'in-group'
+            ? `0 0 0 2.5px ${groupColor ?? color}, 0 0 14px ${groupColor ?? color}99`
+            : groupMode === 'eligible'
+            ? `0 0 0 1.5px ${color}44`
+            : selected
             ? `0 0 0 2px ${color}, 0 0 12px ${color}88`
             : multiSelectable
             ? `0 0 0 1.5px ${color}66`
             : hovered
             ? `0 0 0 1.5px ${color}cc`
             : `0 0 0 1px ${color}55`,
-          background: selected
+          background: groupMode === 'in-group'
+            ? `radial-gradient(circle at 35% 35%, ${groupColor ?? color}44, #1a2535)`
+            : groupMode === 'eligible'
+            ? `radial-gradient(circle at 35% 35%, ${color}15, #0d1117)`
+            : selected
             ? `radial-gradient(circle at 35% 35%, ${color}55, #1e293b)`
             : multiSelectable
             ? `radial-gradient(circle at 35% 35%, ${color}2a, #131d2e)`
             : hovered
             ? `radial-gradient(circle at 35% 35%, ${color}33, #131d2e)`
             : `radial-gradient(circle at 35% 35%, ${color}22, #0f172a)`,
-          transition: 'box-shadow 0.1s, background 0.1s',
+          transition: 'box-shadow 0.15s, background 0.15s',
         }}
       >
+        {/* Group eligible dashed ring — shift-click hint */}
+        {groupMode === 'eligible' && (
+          <div
+            className="absolute rounded-full pointer-events-none"
+            style={{
+              width: diameter + 8,
+              height: diameter + 8,
+              top: -4,
+              left: -4,
+              border: `1.5px dashed ${color}55`,
+              animation: hovered ? undefined : undefined,
+            }}
+          />
+        )}
+
         {/* Multi-selectable dashed ring — centered on the circle */}
-        {multiSelectable && !selected && (
+        {multiSelectable && !selected && !groupMode && (
           <div
             className="absolute rounded-full pointer-events-none"
             style={{

--- a/services/dashboard/src/components/dmx/FixtureNode.tsx
+++ b/services/dashboard/src/components/dmx/FixtureNode.tsx
@@ -7,6 +7,7 @@ interface FixtureNodeProps {
   fixture: DMXFixture
   diameter: number
   universeColor: string
+  groupColor?: string
   selected: boolean
   multiSelectable: boolean
   dragging: boolean
@@ -21,6 +22,7 @@ export function FixtureNode({
   fixture,
   diameter,
   universeColor,
+  groupColor,
   selected,
   multiSelectable,
   dragging,
@@ -107,6 +109,23 @@ export function FixtureNode({
             transition: 'background 0.15s, border-color 0.15s, box-shadow 0.15s',
           }}
         />
+
+        {/* Group color dot — top-left corner */}
+        {groupColor && (
+          <div
+            title="Group"
+            className="absolute rounded-full"
+            style={{
+              width: dotSize,
+              height: dotSize,
+              top: dotOffset,
+              left: dotOffset,
+              background: groupColor,
+              border: `1.5px solid ${groupColor}cc`,
+              boxShadow: `0 0 4px ${groupColor}88`,
+            }}
+          />
+        )}
 
         {/* Universe color inner circle */}
         <div

--- a/services/dashboard/src/hooks/useDMXGroups.ts
+++ b/services/dashboard/src/hooks/useDMXGroups.ts
@@ -1,0 +1,51 @@
+'use client'
+
+import { useState, useEffect, useCallback } from 'react'
+import { dmxApi } from '@/lib/api'
+import { DMXGroup, DMXGroupCreate, DMXGroupUpdate } from '@/lib/types'
+
+export function useDMXGroups() {
+  const [groups, setGroups] = useState<DMXGroup[]>([])
+  const [loading, setLoading] = useState(true)
+  const [error, setError] = useState<string | null>(null)
+
+  const fetchGroups = useCallback(async () => {
+    try {
+      setError(null)
+      const data = await dmxApi.listGroups()
+      setGroups(data)
+    } catch (e) {
+      setError(e instanceof Error ? e.message : 'Failed to load groups')
+    } finally {
+      setLoading(false)
+    }
+  }, [])
+
+  useEffect(() => {
+    fetchGroups()
+  }, [fetchGroups])
+
+  const createGroup = useCallback(async (data: DMXGroupCreate) => {
+    const group = await dmxApi.createGroup(data)
+    setGroups((prev) => [...prev, group])
+    return group
+  }, [])
+
+  const updateGroup = useCallback(async (id: string, data: DMXGroupUpdate) => {
+    const updated = await dmxApi.updateGroup(id, data)
+    setGroups((prev) => prev.map((g) => g.id === id ? updated : g))
+    return updated
+  }, [])
+
+  const deleteGroup = useCallback(async (id: string) => {
+    await dmxApi.deleteGroup(id)
+    setGroups((prev) => prev.filter((g) => g.id !== id))
+  }, [])
+
+  const groupById = useCallback((id: string | undefined | null): DMXGroup | undefined => {
+    if (!id) return undefined
+    return groups.find((g) => g.id === id)
+  }, [groups])
+
+  return { groups, loading, error, refresh: fetchGroups, createGroup, updateGroup, deleteGroup, groupById }
+}

--- a/services/dashboard/src/hooks/useSequencePlayback.ts
+++ b/services/dashboard/src/hooks/useSequencePlayback.ts
@@ -1,4 +1,4 @@
-import { useRef, useState, useCallback, useEffect } from 'react'
+import { useRef, useState, useCallback, useEffect, useMemo } from 'react'
 import { DMXSequence } from '@/lib/types'
 import { playbackApi } from '@/lib/api'
 
@@ -17,7 +17,7 @@ export interface SequencePlaybackStatus {
   loop: boolean
 }
 
-const INITIAL_STATUS: SequencePlaybackStatus = {
+export const INITIAL_STATUS: SequencePlaybackStatus = {
   sequenceId: null,
   playState: 'stopped',
   phase: 'idle',
@@ -27,12 +27,51 @@ const INITIAL_STATUS: SequencePlaybackStatus = {
   loop: false,
 }
 
+type RawEngineStatus = {
+  group_id: string | null
+  sequence_id: string | null
+  play_state: string
+  phase: string
+  cue_index: number
+  progress: number
+  hold_progress: number
+  loop: boolean
+}
+
+function parseStatus(s: RawEngineStatus): SequencePlaybackStatus {
+  return {
+    sequenceId: s.sequence_id,
+    playState: s.play_state as SequencePlayState,
+    phase: s.phase as SequencePhase,
+    cueIndex: s.cue_index,
+    progress: s.progress,
+    holdProgress: s.hold_progress,
+    loop: s.loop,
+  }
+}
+
 // ─── Hook ─────────────────────────────────────────────────────────────────────
 
 export function useSequencePlayback() {
-  const [status, setStatus] = useState<SequencePlaybackStatus>(INITIAL_STATUS)
+  // Key: group_id string | null (null = ungrouped/legacy engine)
+  const [statusMap, setStatusMap] = useState<Map<string | null, SequencePlaybackStatus>>(new Map())
   const pollRef = useRef<ReturnType<typeof setInterval> | null>(null)
-  const loopRef = useRef(false)
+
+  /** Set of group IDs (including null for ungrouped) that have non-stopped playback. */
+  const activeGroupIds = useMemo<Set<string | null>>(() => {
+    const ids = new Set<string | null>()
+    for (const [gid, s] of statusMap.entries()) {
+      if (s.playState !== 'stopped') ids.add(gid)
+    }
+    return ids
+  }, [statusMap])
+
+  /** Get status for a specific group engine. Returns INITIAL_STATUS when no data. */
+  const getGroupStatus = useCallback(
+    (groupId: string | null): SequencePlaybackStatus =>
+      statusMap.get(groupId) ?? INITIAL_STATUS,
+    [statusMap],
+  )
 
   const stopPolling = useCallback(() => {
     if (pollRef.current !== null) {
@@ -45,71 +84,113 @@ export function useSequencePlayback() {
     if (pollRef.current !== null) return
     pollRef.current = setInterval(async () => {
       try {
-        const s = await playbackApi.getStatus()
-        setStatus({
-          sequenceId: s.sequence_id,
-          playState: s.play_state as SequencePlayState,
-          phase: s.phase as SequencePhase,
-          cueIndex: s.cue_index,
-          progress: s.progress,
-          holdProgress: s.hold_progress,
-          loop: s.loop,
-        })
-        if (s.play_state === 'stopped' && s.phase === 'idle') {
-          stopPolling()
+        const result = await playbackApi.getAllStatuses()
+        const next = new Map<string | null, SequencePlaybackStatus>()
+        for (const engine of result.engines) {
+          next.set(engine.group_id ?? null, parseStatus(engine))
         }
+        setStatusMap(next)
+        const allIdle = result.engines.every(
+          (e) => e.play_state === 'stopped' && e.phase === 'idle',
+        )
+        if (allIdle) stopPolling()
       } catch {
         // silently ignore transient poll errors
       }
     }, 150)
   }, [stopPolling])
 
-  const play = useCallback(async (sequence: DMXSequence) => {
-    await playbackApi.play(sequence.id)
-    setStatus({
-      sequenceId: sequence.id,
-      playState: 'playing',
-      phase: 'transitioning',
-      cueIndex: 0,
-      progress: 0,
-      holdProgress: 0,
-      loop: loopRef.current,
+  const play = useCallback(
+    async (sequence: DMXSequence) => {
+      const groupId = sequence.group_id ?? null
+      await playbackApi.play(sequence.id, groupId ?? undefined)
+      setStatusMap((prev) => {
+        const next = new Map(prev)
+        next.set(groupId, {
+          sequenceId: sequence.id,
+          playState: 'playing',
+          phase: 'transitioning',
+          cueIndex: 0,
+          progress: 0,
+          holdProgress: 0,
+          loop: prev.get(groupId)?.loop ?? false,
+        })
+        return next
+      })
+      startPolling()
+    },
+    [startPolling],
+  )
+
+  const pause = useCallback(async (groupId: string | null) => {
+    await playbackApi.pause(groupId ?? undefined)
+    setStatusMap((prev) => {
+      const next = new Map(prev)
+      const cur = prev.get(groupId) ?? INITIAL_STATUS
+      next.set(groupId, { ...cur, playState: 'paused' })
+      return next
     })
-    startPolling()
-  }, [startPolling])
-
-  const pause = useCallback(async () => {
-    await playbackApi.pause()
-    setStatus((prev) => ({ ...prev, playState: 'paused' }))
   }, [])
 
-  const resume = useCallback(async () => {
-    await playbackApi.resume()
-    setStatus((prev) => ({ ...prev, playState: 'playing' }))
-    startPolling()
-  }, [startPolling])
+  const resume = useCallback(
+    async (groupId: string | null) => {
+      await playbackApi.resume(groupId ?? undefined)
+      setStatusMap((prev) => {
+        const next = new Map(prev)
+        const cur = prev.get(groupId) ?? INITIAL_STATUS
+        next.set(groupId, { ...cur, playState: 'playing' })
+        return next
+      })
+      startPolling()
+    },
+    [startPolling],
+  )
 
-  const stop = useCallback(async () => {
-    await playbackApi.stop()
-    stopPolling()
-    setStatus({ ...INITIAL_STATUS, loop: loopRef.current })
-  }, [stopPolling])
-
-  const toggleLoop = useCallback(async () => {
-    const result = await playbackApi.toggleLoop()
-    loopRef.current = result.loop
-    setStatus((prev) => ({ ...prev, loop: result.loop }))
+  const stop = useCallback(async (groupId: string | null) => {
+    await playbackApi.stop(groupId ?? undefined)
+    setStatusMap((prev) => {
+      const next = new Map(prev)
+      next.set(groupId, { ...INITIAL_STATUS })
+      return next
+    })
+    // Polling will naturally stop once all engines report idle
   }, [])
 
-  const fadeOut = useCallback(async (durationMs: number = 3000) => {
-    await playbackApi.fadeOut(durationMs)
-    stopPolling()
-    setStatus({ ...INITIAL_STATUS, loop: loopRef.current })
-  }, [stopPolling])
+  const toggleLoop = useCallback(async (groupId: string | null) => {
+    const result = await playbackApi.toggleLoop(groupId ?? undefined)
+    setStatusMap((prev) => {
+      const next = new Map(prev)
+      const cur = prev.get(groupId) ?? INITIAL_STATUS
+      next.set(groupId, { ...cur, loop: result.loop })
+      return next
+    })
+  }, [])
+
+  const fadeOut = useCallback(async (durationMs: number = 3000, groupId: string | null) => {
+    await playbackApi.fadeOut(durationMs, groupId ?? undefined)
+    setStatusMap((prev) => {
+      const next = new Map(prev)
+      next.set(groupId, { ...INITIAL_STATUS })
+      return next
+    })
+  }, [])
 
   useEffect(() => {
-    return () => { stopPolling() }
+    return () => {
+      stopPolling()
+    }
   }, [stopPolling])
 
-  return { status, play, pause, resume, stop, toggleLoop, fadeOut, startPolling }
+  return {
+    statusMap,
+    getGroupStatus,
+    activeGroupIds,
+    play,
+    pause,
+    resume,
+    stop,
+    toggleLoop,
+    fadeOut,
+    startPolling,
+  }
 }

--- a/services/dashboard/src/lib/api.ts
+++ b/services/dashboard/src/lib/api.ts
@@ -630,6 +630,21 @@ export const playbackApi = {
     }>(`/dmx/playback/status${q}`)
   },
 
+  getAllStatuses: () =>
+    fetchApi<{
+      engines: Array<{
+        group_id: string | null
+        sequence_id: string | null
+        play_state: string
+        phase: string
+        cue_index: number
+        progress: number
+        hold_progress: number
+        loop: boolean
+        fade_progress: number | null
+      }>
+    }>('/dmx/playback/status?group_id=all'),
+
   play: (sequenceId: string, groupId?: string) => {
     const q = groupId ? `?group_id=${groupId}` : ''
     return fetchApi<{ status: string; group_id: string | null }>(`/dmx/playback/play${q}`, {

--- a/services/dashboard/src/lib/api.ts
+++ b/services/dashboard/src/lib/api.ts
@@ -9,6 +9,7 @@ import {
   RoutePresetDetail, RoutingState,
   StreamInfo, StreamSession, StreamSubscriber, StreamTypeInfo, StreamRegistryState,
   BlockedDevice, DeviceProvision, DeviceApproval, DeviceUpdate,
+  DMXGroup, DMXGroupCreate, DMXGroupUpdate,
   DMXNode, DMXNodeCreate, DMXNodeUpdate,
   DMXFixture, DMXFixtureCreate, DMXFixtureUpdate, FixturePositionUpdate,
   DMXCue, DMXCueRecallResult,
@@ -517,6 +518,21 @@ export const cloudApi = {
 }
 // DMX API
 export const dmxApi = {
+  // DMX Groups
+  listGroups: () => fetchApi<DMXGroup[]>('/dmx/groups'),
+  getGroup: (id: string) => fetchApi<DMXGroup>(`/dmx/groups/${id}`),
+  createGroup: (data: DMXGroupCreate) =>
+    fetchApi<DMXGroup>('/dmx/groups', { method: 'POST', body: JSON.stringify(data) }),
+  updateGroup: (id: string, data: DMXGroupUpdate) =>
+    fetchApi<DMXGroup>(`/dmx/groups/${id}`, { method: 'PATCH', body: JSON.stringify(data) }),
+  deleteGroup: (id: string) =>
+    fetchApi<{ status: string; id: string }>(`/dmx/groups/${id}`, { method: 'DELETE' }),
+  bulkAssignFixturesToGroup: (groupId: string, fixtureIds: string[]) =>
+    fetchApi<{ assigned: number; group_id: string }>(`/dmx/groups/${groupId}/fixtures`, {
+      method: 'POST',
+      body: JSON.stringify(fixtureIds),
+    }),
+
   // Art-Net Nodes
   listNodes: () => fetchApi<DMXNode[]>('/dmx/nodes'),
   getNode: (id: string) => fetchApi<DMXNode>(`/dmx/nodes/${id}`),
@@ -562,8 +578,8 @@ export const dmxApi = {
 
   // DMX Cues
   listCues: () => fetchApi<DMXCue[]>('/dmx/cues'),
-  saveCue: (name: string) =>
-    fetchApi<DMXCue>('/dmx/cues', { method: 'POST', body: JSON.stringify({ name }) }),
+  saveCue: (name: string, groupId?: string) =>
+    fetchApi<DMXCue>('/dmx/cues', { method: 'POST', body: JSON.stringify({ name, group_id: groupId ?? null }) }),
   recallCue: (id: string) =>
     fetchApi<DMXCueRecallResult>(`/dmx/cues/${id}/recall`, { method: 'POST' }),
   updateCueSnapshot: (id: string) =>
@@ -579,8 +595,8 @@ export const dmxApi = {
 
   // DMX Sequences
   listSequences: () => fetchApi<DMXSequence[]>('/dmx/sequences'),
-  createSequence: (name: string) =>
-    fetchApi<DMXSequence>('/dmx/sequences', { method: 'POST', body: JSON.stringify({ name }) }),
+  createSequence: (name: string, groupId?: string) =>
+    fetchApi<DMXSequence>('/dmx/sequences', { method: 'POST', body: JSON.stringify({ name, group_id: groupId ?? null }) }),
   reorderSequences: (ids: string[]) =>
     fetchApi<{ reordered: number }>('/dmx/sequences/reorder', { method: 'PUT', body: JSON.stringify(ids) }),
   renameSequence: (id: string, name: string) =>
@@ -599,8 +615,10 @@ export const dmxApi = {
 
 // DMX Playback API
 export const playbackApi = {
-  getStatus: () =>
-    fetchApi<{
+  getStatus: (groupId?: string) => {
+    const q = groupId ? `?group_id=${groupId}` : ''
+    return fetchApi<{
+      group_id: string | null
       sequence_id: string | null
       play_state: string
       phase: string
@@ -609,37 +627,52 @@ export const playbackApi = {
       hold_progress: number
       loop: boolean
       fade_progress: number | null
-    }>('/dmx/playback/status'),
+    }>(`/dmx/playback/status${q}`)
+  },
 
-  play: (sequenceId: string) =>
-    fetchApi<{ status: string }>('/dmx/playback/play', {
+  play: (sequenceId: string, groupId?: string) => {
+    const q = groupId ? `?group_id=${groupId}` : ''
+    return fetchApi<{ status: string; group_id: string | null }>(`/dmx/playback/play${q}`, {
       method: 'POST',
       body: JSON.stringify({ sequence_id: sequenceId }),
-    }),
+    })
+  },
 
-  pause: () =>
-    fetchApi<{ status: string }>('/dmx/playback/pause', { method: 'POST' }),
+  pause: (groupId?: string) => {
+    const q = groupId ? `?group_id=${groupId}` : ''
+    return fetchApi<{ status: string }>(`/dmx/playback/pause${q}`, { method: 'POST' })
+  },
 
-  resume: () =>
-    fetchApi<{ status: string }>('/dmx/playback/resume', { method: 'POST' }),
+  resume: (groupId?: string) => {
+    const q = groupId ? `?group_id=${groupId}` : ''
+    return fetchApi<{ status: string }>(`/dmx/playback/resume${q}`, { method: 'POST' })
+  },
 
-  stop: () =>
-    fetchApi<{ status: string }>('/dmx/playback/stop', { method: 'POST' }),
+  stop: (groupId?: string) => {
+    const q = groupId ? `?group_id=${groupId}` : ''
+    return fetchApi<{ status: string }>(`/dmx/playback/stop${q}`, { method: 'POST' })
+  },
 
-  toggleLoop: () =>
-    fetchApi<{ loop: boolean }>('/dmx/playback/toggle-loop', { method: 'POST' }),
+  toggleLoop: (groupId?: string) => {
+    const q = groupId ? `?group_id=${groupId}` : ''
+    return fetchApi<{ loop: boolean }>(`/dmx/playback/toggle-loop${q}`, { method: 'POST' })
+  },
 
-  fadeOut: (durationMs: number = 3000) =>
-    fetchApi<{ status: string }>('/dmx/playback/fadeout', {
+  fadeOut: (durationMs: number = 3000, groupId?: string) => {
+    const q = groupId ? `?group_id=${groupId}` : ''
+    return fetchApi<{ status: string }>(`/dmx/playback/fadeout${q}`, {
       method: 'POST',
       body: JSON.stringify({ duration_ms: durationMs }),
-    }),
+    })
+  },
 
-  recallCueFade: (fromCueId: string | null, toCueId: string, durationMs: number) =>
-    fetchApi<{ status: string }>('/dmx/playback/cue-fade', {
+  recallCueFade: (fromCueId: string | null, toCueId: string, durationMs: number, groupId?: string) => {
+    const q = groupId ? `?group_id=${groupId}` : ''
+    return fetchApi<{ status: string }>(`/dmx/playback/cue-fade${q}`, {
       method: 'POST',
       body: JSON.stringify({ from_cue_id: fromCueId, to_cue_id: toCueId, duration_ms: durationMs }),
-    }),
+    })
+  },
 
   blackout: () =>
     fetchApi<{ status: string; fixtures: number }>('/dmx/playback/blackout', { method: 'POST' }),

--- a/services/dashboard/src/lib/types.ts
+++ b/services/dashboard/src/lib/types.ts
@@ -422,6 +422,34 @@ export interface UniverseConfig {
   color?: string
 }
 
+export interface DMXGroup {
+  id: string
+  name: string
+  color?: string
+  sort_order: number
+  metadata: Record<string, unknown>
+  created_at: string
+  updated_at: string
+  // populated by GET /dmx/groups/{id}
+  fixture_count?: number
+  cue_count?: number
+  sequence_count?: number
+}
+
+export interface DMXGroupCreate {
+  name: string
+  color?: string
+  sort_order?: number
+  metadata?: Record<string, unknown>
+}
+
+export interface DMXGroupUpdate {
+  name?: string
+  color?: string
+  sort_order?: number
+  metadata?: Record<string, unknown>
+}
+
 export interface DMXNode {
   id: string
   name: string
@@ -498,6 +526,7 @@ export interface DMXFixture {
   /** Slug of the linked entity — read-only on the fixture, derived via JOIN. */
   entity_slug?: string
   ofl_fixture_id?: string
+  group_id?: string
   position_x: number
   position_y: number
   sort_order: number
@@ -519,6 +548,7 @@ export interface DMXFixtureCreate {
   /** Desired slug for the auto-created linked entity. Returns 409 if already in use. */
   entity_slug?: string
   ofl_fixture_id?: string
+  group_id?: string
   position_x?: number
   position_y?: number
   metadata?: Record<string, unknown>
@@ -537,6 +567,7 @@ export interface DMXFixtureUpdate {
   entity_id?: string | null
   /** New slug for the linked entity. Returns 409 if already in use. */
   entity_slug?: string
+  group_id?: string
   position_x?: number
   position_y?: number
   metadata?: Record<string, unknown>
@@ -559,6 +590,7 @@ export interface DMXCue {
   name: string
   fade_duration: number
   sort_order: number
+  group_id?: string
   created_at: string
   updated_at: string
   /** Art-Net nodes and universes used by fixtures snapshotted in this cue. */
@@ -587,6 +619,7 @@ export interface DMXSequence {
   name: string
   fade_out_duration: number
   sort_order: number
+  group_id?: string
   cue_placements: DMXCuePlacement[]
   created_at: string
   updated_at: string

--- a/services/dashboard/src/lib/types.ts
+++ b/services/dashboard/src/lib/types.ts
@@ -495,6 +495,8 @@ export interface DMXFixture {
   fixture_mode?: string
   channel_map: Record<string, ChannelMapping>
   entity_id?: string
+  /** Slug of the linked entity — read-only on the fixture, derived via JOIN. */
+  entity_slug?: string
   ofl_fixture_id?: string
   position_x: number
   position_y: number
@@ -514,6 +516,8 @@ export interface DMXFixtureCreate {
   fixture_mode?: string
   channel_map?: Record<string, ChannelMapping>
   entity_id?: string
+  /** Desired slug for the auto-created linked entity. Returns 409 if already in use. */
+  entity_slug?: string
   ofl_fixture_id?: string
   position_x?: number
   position_y?: number
@@ -531,6 +535,8 @@ export interface DMXFixtureUpdate {
   channel_map?: Record<string, ChannelMapping>
   /** Pass null explicitly to unlink from an entity; omit to leave unchanged. */
   entity_id?: string | null
+  /** New slug for the linked entity. Returns 409 if already in use. */
+  entity_slug?: string
   position_x?: number
   position_y?: number
   metadata?: Record<string, unknown>
@@ -542,6 +548,12 @@ export interface FixturePositionUpdate {
   position_y: number
 }
 
+export interface DMXCueNode {
+  node_id: string
+  node_name: string
+  universes: number[]
+}
+
 export interface DMXCue {
   id: string
   name: string
@@ -549,6 +561,8 @@ export interface DMXCue {
   sort_order: number
   created_at: string
   updated_at: string
+  /** Art-Net nodes and universes used by fixtures snapshotted in this cue. */
+  nodes: DMXCueNode[]
 }
 
 export interface DMXCueRecallResult {

--- a/services/dashboard/src/lib/types.ts
+++ b/services/dashboard/src/lib/types.ts
@@ -567,7 +567,8 @@ export interface DMXFixtureUpdate {
   entity_id?: string | null
   /** New slug for the linked entity. Returns 409 if already in use. */
   entity_slug?: string
-  group_id?: string
+  /** Pass null explicitly to remove from a group; omit to leave unchanged. */
+  group_id?: string | null
   position_x?: number
   position_y?: number
   metadata?: Record<string, unknown>

--- a/services/fleet-manager/dmx_playback_engine.py
+++ b/services/fleet-manager/dmx_playback_engine.py
@@ -113,6 +113,7 @@ class DMXGroupEngine:
         self._paused_elapsed: float = 0.0
         self._last_dmx_send: float = 0.0
         self._loop: bool = False
+        self._fadeout_ms_on_complete: Optional[float] = None
         self._progress: float = 0.0
         self._hold_progress: float = 0.0
         self._fade_progress: Optional[float] = None
@@ -142,6 +143,7 @@ class DMXGroupEngine:
             "loop": self._loop,
             "fade_progress": self._fade_progress,
             "interval_ms": round(self._send_interval * 1000),
+            "fadeout_ms_on_complete": self._fadeout_ms_on_complete,
         }
 
     async def load_settings(self) -> None:
@@ -178,7 +180,7 @@ class DMXGroupEngine:
 
     # ── Public API ────────────────────────────────────────────────────────────
 
-    async def play(self, sequence_id: str) -> bool:
+    async def play(self, sequence_id: str, loop: bool = False, fadeout_ms: Optional[float] = None) -> bool:
         await self._cancel_tasks()
         loaded = await self._load_sequence(sequence_id)
         if not loaded:
@@ -192,6 +194,8 @@ class DMXGroupEngine:
         self._cue_index = 0
         self._phase = 'transitioning' if first_transition > 0 else 'holding'
         self._play_state = 'playing'
+        self._loop = loop
+        self._fadeout_ms_on_complete = fadeout_ms
         self._phase_start = asyncio.get_event_loop().time()
         self._paused_elapsed = 0.0
         self._last_dmx_send = 0.0
@@ -403,7 +407,10 @@ class DMXGroupEngine:
                         self._paused_elapsed = 0.0
                         self._last_dmx_send = 0.0
                     else:
-                        # Sequence complete — clear entity IDs and stop (lights stay at last cue)
+                        # Sequence complete — stop tick loop; lights stay at last cue unless
+                        # fadeout was configured, in which case kick off the fade background task.
+                        if self._fadeout_ms_on_complete is not None:
+                            fixtures = list(self._loaded[self._cue_index]['fixtures']) if self._loaded else []
                         self._play_state = 'stopped'
                         self._sequence_id = None
                         self._loaded = []
@@ -413,6 +420,10 @@ class DMXGroupEngine:
                         await self._set_dmx_lighting_active(
                             active_sequence_id=None, active_cue_id=None
                         )
+                        if self._fadeout_ms_on_complete is not None and fixtures:
+                            self._fade_task = asyncio.create_task(
+                                self._run_fade_out(fixtures, self._fadeout_ms_on_complete)
+                            )
                 else:
                     self._cue_index = next_idx
                     self._phase = 'transitioning'

--- a/services/fleet-manager/dmx_playback_engine.py
+++ b/services/fleet-manager/dmx_playback_engine.py
@@ -87,14 +87,19 @@ def _interpolate_state(
     return result
 
 
-class DMXPlaybackEngine:
+class DMXGroupEngine:
     """
-    Singleton playback engine.  Call play(), pause(), resume(), stop(),
-    toggle_loop(), fade_out(), and recall_cue_fade() from FastAPI routes.
-    Status is exposed via the .status property.
+    Per-group playback engine.  One instance per DMX group (None key = ungrouped).
+    Call play(), pause(), resume(), stop(), toggle_loop(), fade_out(), and
+    recall_cue_fade() from FastAPI routes.  Status is exposed via the .status property.
+
+    Uses jsonb_set merge semantics for entity state updates so multiple group
+    engines can drive different channels on the same entity simultaneously (LTP).
     """
 
-    def __init__(self):
+    def __init__(self, group_id: Optional[str] = None):
+        self.group_id: Optional[str] = group_id  # None = ungrouped (legacy) engine
+
         # Configurable tick interval (seconds); loaded from DB at startup
         self._send_interval: float = DMX_SEND_INTERVAL_DEFAULT
 
@@ -127,6 +132,7 @@ class DMXPlaybackEngine:
     @property
     def status(self) -> dict:
         return {
+            "group_id": self.group_id,
             "sequence_id": self._sequence_id,
             "play_state": self._play_state,
             "phase": self._phase,
@@ -534,7 +540,12 @@ class DMXPlaybackEngine:
         await self._batch_update(updates)
 
     async def _batch_update(self, updates: list):
-        """Batch-update entity states in DB, then broadcast each change to NATS."""
+        """Batch-update entity states via jsonb merge, then broadcast each change to NATS.
+
+        Uses `state || patch` (jsonb concatenation) instead of a full state replace so
+        multiple group engines can write different channels on the same entity
+        simultaneously without clobbering each other (LTP semantics).
+        """
         if not updates:
             return
         try:
@@ -546,9 +557,10 @@ class DMXPlaybackEngine:
                 for entity_id, _, new_state in updates:
                     await db.execute(text("""
                         UPDATE entities
-                        SET state = CAST(:state AS jsonb), state_updated_at = NOW()
+                        SET state = COALESCE(state, '{}'::jsonb) || CAST(:patch AS jsonb),
+                            state_updated_at = NOW()
                         WHERE id = CAST(:id AS uuid)
-                    """), {"state": json.dumps(new_state), "id": entity_id})
+                    """), {"patch": json.dumps(new_state), "id": entity_id})
                 await db.commit()
 
             for entity_id, prev_state, new_state in updates:
@@ -747,5 +759,54 @@ class DMXPlaybackEngine:
         await self._cancel_tasks()
 
 
-# Singleton instance
-playback_engine = DMXPlaybackEngine()
+# =============================================================================
+# Engine Registry — one DMXGroupEngine per group (None key = ungrouped/legacy)
+# =============================================================================
+
+class DMXEngineRegistry:
+    """
+    Singleton registry of per-group playback engines.
+
+    Key None  →  ungrouped (legacy) engine — backward-compatible with all
+                 existing API calls that omit group_id.
+    Key <str> →  one engine per DMX group UUID.
+
+    Engines are created on demand and never destroyed (they just sit idle).
+    This preserves playback state across API calls without re-instantiation.
+    """
+
+    def __init__(self):
+        self._engines: dict[Optional[str], DMXGroupEngine] = {
+            None: DMXGroupEngine(group_id=None)
+        }
+        self._lock = asyncio.Lock()
+
+    def get(self, group_id: Optional[str] = None) -> DMXGroupEngine:
+        """Return the engine for the given group_id, creating it on first access."""
+        if group_id not in self._engines:
+            self._engines[group_id] = DMXGroupEngine(group_id=group_id)
+        return self._engines[group_id]
+
+    @property
+    def ungrouped(self) -> DMXGroupEngine:
+        """Convenience accessor for the legacy ungrouped engine."""
+        return self._engines[None]
+
+    def all_statuses(self) -> list:
+        """Return status dicts for all engines that are not idle."""
+        return [e.status for e in self._engines.values()]
+
+    async def load_settings(self) -> None:
+        """Load persisted settings into the ungrouped (legacy) engine at startup."""
+        await self._engines[None].load_settings()
+
+    async def shutdown_all(self) -> None:
+        for engine in self._engines.values():
+            await engine.shutdown()
+
+
+# Registry singleton — used by dmx_router.py playback endpoints
+engine_registry = DMXEngineRegistry()
+
+# Backward-compatible alias — existing imports of `playback_engine` continue to work
+playback_engine = engine_registry.ungrouped

--- a/services/fleet-manager/dmx_router.py
+++ b/services/fleet-manager/dmx_router.py
@@ -94,8 +94,13 @@ async def _sync_dmx_lighting_entity(db: AsyncSession) -> None:
             continue
         play_state = engine_status.get("play_state", "stopped")
         if play_state != "stopped":
+            fadeout_ms_val = engine_status.get("fadeout_ms_on_complete")
             group_playback[str(gid)] = {
-                "active_sequence_id": engine_status.get("sequence_id"),
+                "active_sequence_id": {
+                    "id": engine_status.get("sequence_id"),
+                    "loop": engine_status.get("loop", False),
+                    **({"fadeout": fadeout_ms_val / 1000.0} if fadeout_ms_val is not None else {}),
+                },
                 "active_cue_id": None,
             }
 
@@ -1716,6 +1721,8 @@ async def remove_cue_from_sequence(
 
 class PlaybackPlayRequest(BaseModel):
     sequence_id: str
+    loop: bool = False
+    fadeout_ms: Optional[float] = None
 
 
 class PlaybackFadeOutRequest(BaseModel):
@@ -1765,7 +1772,7 @@ async def update_playback_config(data: PlaybackConfigUpdate):
 async def playback_play(data: PlaybackPlayRequest, group_id: Optional[str] = None):
     """Start sequence playback. Pass group_id to target a specific group's engine."""
     from dmx_playback_engine import engine_registry
-    ok = await engine_registry.get(group_id).play(data.sequence_id)
+    ok = await engine_registry.get(group_id).play(data.sequence_id, loop=data.loop, fadeout_ms=data.fadeout_ms)
     if not ok:
         raise HTTPException(status_code=404, detail="Sequence not found or has no cue placements")
     return {"status": "playing", "group_id": group_id}

--- a/services/fleet-manager/dmx_router.py
+++ b/services/fleet-manager/dmx_router.py
@@ -148,6 +148,10 @@ class DMXFixtureCreate(BaseModel):
     channel_map: Dict[str, ChannelMapping] = {}
     # UUID validated at model layer; existence validated against entities table at write time
     entity_id: Optional[UUID] = None
+    # Desired slug for the auto-created linked entity — passed through to POST /entities.
+    # Conflict checking happens in the entity router (409 if already in use).
+    # Not stored on the fixture record; derived from the linked entity on read.
+    entity_slug: Optional[str] = None
     ofl_fixture_id: Optional[str] = None
     position_x: float = 100.0
     position_y: float = 100.0
@@ -166,6 +170,9 @@ class DMXFixtureUpdate(BaseModel):
     # Pass null explicitly to unlink; omit to leave unchanged.
     # exclude_unset=True in model_dump() distinguishes "omitted" from "set to null".
     entity_id: Optional[UUID] = Field(default=None)
+    # New slug for the linked entity. Applied to entities.slug — not stored on the fixture.
+    # Returns 409 if the slug is already in use by another entity.
+    entity_slug: Optional[str] = None
     position_x: Optional[float] = None
     position_y: Optional[float] = None
     metadata: Optional[Dict[str, Any]] = None
@@ -220,6 +227,7 @@ def _row_to_fixture(row) -> dict:
         "fixture_mode": row.fixture_mode,
         "channel_map": row.channel_map if row.channel_map else {},
         "entity_id": str(row.entity_id) if row.entity_id else None,
+        "entity_slug": getattr(row, "entity_slug", None),
         "ofl_fixture_id": str(row.ofl_fixture_id) if row.ofl_fixture_id else None,
         "position_x": row.position_x,
         "position_y": row.position_y,
@@ -230,15 +238,18 @@ def _row_to_fixture(row) -> dict:
     }
 
 
-# SQL fragment for selecting fixtures with OFL manufacturer + model joined in
+# SQL fragment for selecting fixtures with OFL manufacturer + model joined in,
+# and entity slug derived from the linked entity (no slug column on dmx_fixtures).
 _FIXTURE_SELECT = """
     SELECT
         f.*,
         m.name AS ofl_manufacturer,
-        of2.name AS ofl_model
+        of2.name AS ofl_model,
+        e.slug AS entity_slug
     FROM dmx_fixtures f
     LEFT JOIN ofl_fixtures of2 ON of2.id = f.ofl_fixture_id
     LEFT JOIN ofl_manufacturers m ON m.key = of2.manufacturer_key
+    LEFT JOIN entities e ON e.id = f.entity_id
 """
 
 
@@ -670,7 +681,12 @@ async def update_fixture(
         raise HTTPException(status_code=404, detail="DMX fixture not found")
 
     updates = data.model_dump(exclude_unset=True)
-    if not updates:
+
+    # entity_slug targets the linked entity, not the fixture table — handle separately.
+    import re as _re
+    new_entity_slug = updates.pop("entity_slug", None)
+
+    if not updates and new_entity_slug is None:
         result = await db.execute(
             text(f"{_FIXTURE_SELECT} WHERE f.id = :id"), {"id": str(fixture_id)}
         )
@@ -684,29 +700,55 @@ async def update_fixture(
     if "node_id" in updates and updates["node_id"] is not None:
         await _require_node(updates["node_id"], db)
 
-    set_clauses = []
-    params: Dict[str, Any] = {"id": str(fixture_id)}
-    for key, value in updates.items():
-        if key == "channel_map":
-            set_clauses.append(f"{key} = CAST(:{key} AS jsonb)")
-            params[key] = json.dumps(
-                {k: (v if isinstance(v, dict) else v.model_dump()) for k, v in value.items()}
+    # Apply entity_slug change to the linked entity
+    if new_entity_slug is not None:
+        if not _re.match(r'^[a-z0-9][a-z0-9-]*$', new_entity_slug):
+            raise HTTPException(status_code=422, detail="entity_slug must be lowercase alphanumeric with hyphens and start with a letter or digit")
+        # Resolve the current entity_id (may be changing in this same request)
+        target_entity_id = updates.get("entity_id") or None
+        if target_entity_id is None:
+            eid_row = await db.execute(
+                text("SELECT entity_id FROM dmx_fixtures WHERE id = :id"), {"id": str(fixture_id)}
             )
-        elif key == "metadata":
-            set_clauses.append(f"{key} = CAST(:{key} AS jsonb)")
-            params[key] = json.dumps(value)
-        elif key in ("entity_id", "node_id") and value is not None:
-            # UUID fields — store as string; None passes through as NULL below
-            set_clauses.append(f"{key} = :{key}")
-            params[key] = str(value)
-        else:
-            # Handles None (→ NULL) for entity_id unlinking, and scalar fields
-            set_clauses.append(f"{key} = :{key}")
-            params[key] = value
+            eid_row = eid_row.fetchone()
+            target_entity_id = eid_row.entity_id if eid_row else None
+        if target_entity_id:
+            conflict = await db.execute(
+                text("SELECT id FROM entities WHERE slug = :slug AND id != :eid"),
+                {"slug": new_entity_slug, "eid": str(target_entity_id)},
+            )
+            if conflict.fetchone():
+                raise HTTPException(status_code=409, detail=f"Slug '{new_entity_slug}' is already in use")
+            await db.execute(
+                text("UPDATE entities SET slug = :slug, updated_at = NOW() WHERE id = :eid"),
+                {"slug": new_entity_slug, "eid": str(target_entity_id)},
+            )
 
-    await db.execute(text(
-        f"UPDATE dmx_fixtures SET {', '.join(set_clauses)} WHERE id = :id"
-    ), params)
+    if updates:
+        set_clauses = []
+        params: Dict[str, Any] = {"id": str(fixture_id)}
+        for key, value in updates.items():
+            if key == "channel_map":
+                set_clauses.append(f"{key} = CAST(:{key} AS jsonb)")
+                params[key] = json.dumps(
+                    {k: (v if isinstance(v, dict) else v.model_dump()) for k, v in value.items()}
+                )
+            elif key == "metadata":
+                set_clauses.append(f"{key} = CAST(:{key} AS jsonb)")
+                params[key] = json.dumps(value)
+            elif key in ("entity_id", "node_id") and value is not None:
+                # UUID fields — store as string; None passes through as NULL below
+                set_clauses.append(f"{key} = :{key}")
+                params[key] = str(value)
+            else:
+                # Handles None (→ NULL) for entity_id unlinking, and scalar fields
+                set_clauses.append(f"{key} = :{key}")
+                params[key] = value
+
+        await db.execute(text(
+            f"UPDATE dmx_fixtures SET {', '.join(set_clauses)} WHERE id = :id"
+        ), params)
+
     await db.commit()
 
     result = await db.execute(
@@ -945,12 +987,52 @@ def _row_to_cue(row) -> dict:
 
 @router.get("/cues")
 async def list_cues(db: AsyncSession = Depends(get_db)):
-    """List all saved cues ordered by sort_order, then created_at."""
+    """List all saved cues ordered by sort_order, then created_at.
+
+    Each cue includes a `nodes` summary: the distinct Art-Net nodes and universes
+    referenced by the fixtures snapshotted in that cue, derived via JOIN — no
+    denormalized data stored on the cue record itself.
+    """
     rows = await db.execute(text("""
         SELECT id, name, fade_duration, sort_order, created_at, updated_at
         FROM dmx_cues ORDER BY sort_order ASC, created_at ASC
     """))
-    return [_row_to_cue(r) for r in rows.fetchall()]
+    cues = [_row_to_cue(r) for r in rows.fetchall()]
+
+    if not cues:
+        return cues
+
+    # Build node/universe summary per cue in one query
+    cue_ids = [c["id"] for c in cues]
+    node_rows = await db.execute(text("""
+        SELECT
+            cf.cue_id::text,
+            n.id::text   AS node_id,
+            n.name       AS node_name,
+            f.universe
+        FROM dmx_cue_fixtures cf
+        JOIN dmx_fixtures f  ON f.entity_id = cf.entity_id
+        JOIN dmx_nodes    n  ON n.id = f.node_id
+        WHERE cf.cue_id = ANY(:ids)
+        GROUP BY cf.cue_id, n.id, n.name, f.universe
+        ORDER BY n.name, f.universe
+    """), {"ids": [c["id"] for c in cues]})
+
+    # Aggregate: {cue_id: {node_id: {name, universes: set}}}
+    from collections import defaultdict
+    cue_nodes: dict = defaultdict(lambda: defaultdict(lambda: {"name": "", "universes": set()}))
+    for r in node_rows.fetchall():
+        cue_nodes[r.cue_id][r.node_id]["name"] = r.node_name
+        cue_nodes[r.cue_id][r.node_id]["universes"].add(r.universe)
+
+    for cue in cues:
+        node_map = cue_nodes.get(cue["id"], {})
+        cue["nodes"] = [
+            {"node_id": nid, "node_name": info["name"], "universes": sorted(info["universes"])}
+            for nid, info in node_map.items()
+        ]
+
+    return cues
 
 
 @router.post("/cues")

--- a/services/fleet-manager/dmx_router.py
+++ b/services/fleet-manager/dmx_router.py
@@ -137,6 +137,20 @@ class ChannelMapping(BaseModel):
     enum_dmx_values: Optional[Dict[str, int]] = None
 
 
+class DMXGroupCreate(BaseModel):
+    name: str
+    color: Optional[str] = None
+    sort_order: int = 0
+    metadata: Dict[str, Any] = {}
+
+
+class DMXGroupUpdate(BaseModel):
+    name: Optional[str] = None
+    color: Optional[str] = None
+    sort_order: Optional[int] = None
+    metadata: Optional[Dict[str, Any]] = None
+
+
 class DMXFixtureCreate(BaseModel):
     name: str
     label: Optional[str] = None
@@ -153,6 +167,7 @@ class DMXFixtureCreate(BaseModel):
     # Not stored on the fixture record; derived from the linked entity on read.
     entity_slug: Optional[str] = None
     ofl_fixture_id: Optional[str] = None
+    group_id: Optional[UUID] = None
     position_x: float = 100.0
     position_y: float = 100.0
     metadata: Dict[str, Any] = {}
@@ -173,6 +188,7 @@ class DMXFixtureUpdate(BaseModel):
     # New slug for the linked entity. Applied to entities.slug — not stored on the fixture.
     # Returns 409 if the slug is already in use by another entity.
     entity_slug: Optional[str] = None
+    group_id: Optional[UUID] = None
     position_x: Optional[float] = None
     position_y: Optional[float] = None
     metadata: Optional[Dict[str, Any]] = None
@@ -213,6 +229,18 @@ def _row_to_node(row) -> dict:
     }
 
 
+def _row_to_group(row) -> dict:
+    return {
+        "id": str(row.id),
+        "name": row.name,
+        "color": row.color,
+        "sort_order": row.sort_order,
+        "metadata": row.metadata if row.metadata else {},
+        "created_at": row.created_at.isoformat() if row.created_at else None,
+        "updated_at": row.updated_at.isoformat() if row.updated_at else None,
+    }
+
+
 def _row_to_fixture(row) -> dict:
     return {
         "id": str(row.id),
@@ -229,6 +257,7 @@ def _row_to_fixture(row) -> dict:
         "entity_id": str(row.entity_id) if row.entity_id else None,
         "entity_slug": getattr(row, "entity_slug", None),
         "ofl_fixture_id": str(row.ofl_fixture_id) if row.ofl_fixture_id else None,
+        "group_id": str(row.group_id) if row.group_id else None,
         "position_x": row.position_x,
         "position_y": row.position_y,
         "sort_order": row.sort_order if hasattr(row, "sort_order") else 0,
@@ -355,6 +384,128 @@ async def _require_node(node_id: UUID, db: AsyncSession) -> None:
     )
     if not result.fetchone():
         raise HTTPException(status_code=404, detail="DMX node not found")
+
+
+# =============================================================================
+# DMX Group Endpoints
+# =============================================================================
+
+@router.get("/groups")
+async def list_groups(db: AsyncSession = Depends(get_db)):
+    """List all DMX groups ordered by sort_order."""
+    result = await db.execute(text("""
+        SELECT id, name, color, sort_order, metadata, created_at, updated_at
+        FROM dmx_groups ORDER BY sort_order ASC, created_at ASC
+    """))
+    return [_row_to_group(r) for r in result.fetchall()]
+
+
+@router.post("/groups", status_code=201)
+async def create_group(data: DMXGroupCreate, db: AsyncSession = Depends(get_db)):
+    """Create a new DMX group."""
+    row = await db.execute(text("""
+        INSERT INTO dmx_groups (name, color, sort_order, metadata)
+        VALUES (:name, :color, :sort_order, CAST(:metadata AS jsonb))
+        RETURNING id, name, color, sort_order, metadata, created_at, updated_at
+    """), {
+        "name": data.name,
+        "color": data.color,
+        "sort_order": data.sort_order,
+        "metadata": json.dumps(data.metadata),
+    })
+    await db.commit()
+    return _row_to_group(row.fetchone())
+
+
+@router.get("/groups/{group_id}")
+async def get_group(group_id: UUID, db: AsyncSession = Depends(get_db)):
+    """Get a single DMX group with member fixture/cue/sequence counts."""
+    result = await db.execute(text("""
+        SELECT id, name, color, sort_order, metadata, created_at, updated_at
+        FROM dmx_groups WHERE id = :id
+    """), {"id": str(group_id)})
+    row = result.fetchone()
+    if not row:
+        raise HTTPException(status_code=404, detail="Group not found")
+    group = _row_to_group(row)
+
+    counts = await db.execute(text("""
+        SELECT
+            (SELECT COUNT(*) FROM dmx_fixtures  WHERE group_id = :id) AS fixture_count,
+            (SELECT COUNT(*) FROM dmx_cues      WHERE group_id = :id) AS cue_count,
+            (SELECT COUNT(*) FROM dmx_sequences WHERE group_id = :id) AS sequence_count
+    """), {"id": str(group_id)})
+    c = counts.fetchone()
+    group["fixture_count"] = c.fixture_count
+    group["cue_count"] = c.cue_count
+    group["sequence_count"] = c.sequence_count
+    return group
+
+
+@router.patch("/groups/{group_id}")
+async def update_group(group_id: UUID, data: DMXGroupUpdate, db: AsyncSession = Depends(get_db)):
+    """Update a DMX group's name, color, or sort_order."""
+    updates = data.model_dump(exclude_unset=True)
+    if not updates:
+        result = await db.execute(text(
+            "SELECT id, name, color, sort_order, metadata, created_at, updated_at FROM dmx_groups WHERE id = :id"
+        ), {"id": str(group_id)})
+        row = result.fetchone()
+        if not row:
+            raise HTTPException(status_code=404, detail="Group not found")
+        return _row_to_group(row)
+
+    set_clauses = []
+    params: Dict[str, Any] = {"id": str(group_id)}
+    for key, value in updates.items():
+        if key == "metadata":
+            set_clauses.append(f"{key} = CAST(:{key} AS jsonb)")
+            params[key] = json.dumps(value)
+        else:
+            set_clauses.append(f"{key} = :{key}")
+            params[key] = value
+
+    row = await db.execute(text(
+        f"UPDATE dmx_groups SET {', '.join(set_clauses)}, updated_at = NOW() WHERE id = :id "
+        "RETURNING id, name, color, sort_order, metadata, created_at, updated_at"
+    ), params)
+    updated = row.fetchone()
+    if not updated:
+        raise HTTPException(status_code=404, detail="Group not found")
+    await db.commit()
+    return _row_to_group(updated)
+
+
+@router.delete("/groups/{group_id}")
+async def delete_group(group_id: UUID, db: AsyncSession = Depends(get_db)):
+    """Delete a DMX group. Fixtures, cues, and sequences in this group become ungrouped (group_id = NULL)."""
+    row = await db.execute(text(
+        "DELETE FROM dmx_groups WHERE id = :id RETURNING id"
+    ), {"id": str(group_id)})
+    if not row.fetchone():
+        raise HTTPException(status_code=404, detail="Group not found")
+    await db.commit()
+    return {"status": "deleted", "id": str(group_id)}
+
+
+@router.post("/groups/{group_id}/fixtures")
+async def bulk_assign_fixtures_to_group(
+    group_id: UUID,
+    fixture_ids: List[str],
+    db: AsyncSession = Depends(get_db),
+):
+    """Bulk assign fixtures to a group. Pass an empty list to ungroup all fixtures in this group."""
+    # Verify group exists
+    result = await db.execute(text("SELECT id FROM dmx_groups WHERE id = :id"), {"id": str(group_id)})
+    if not result.fetchone():
+        raise HTTPException(status_code=404, detail="Group not found")
+
+    if fixture_ids:
+        await db.execute(text("""
+            UPDATE dmx_fixtures SET group_id = :gid WHERE id = ANY(:ids)
+        """), {"gid": str(group_id), "ids": fixture_ids})
+    await db.commit()
+    return {"assigned": len(fixture_ids), "group_id": str(group_id)}
 
 
 # =============================================================================
@@ -607,11 +758,11 @@ async def create_fixture(data: DMXFixtureCreate, db: AsyncSession = Depends(get_
         INSERT INTO dmx_fixtures (
             id, name, label, node_id, universe,
             start_channel, channel_count, fixture_mode, channel_map,
-            entity_id, ofl_fixture_id, position_x, position_y, sort_order, metadata
+            entity_id, ofl_fixture_id, group_id, position_x, position_y, sort_order, metadata
         ) VALUES (
             :id, :name, :label, :node_id, :universe,
             :start_channel, :channel_count, :fixture_mode, CAST(:channel_map AS jsonb),
-            :entity_id, :ofl_fixture_id, :position_x, :position_y,
+            :entity_id, :ofl_fixture_id, :group_id, :position_x, :position_y,
             COALESCE((SELECT MAX(sort_order) + 1 FROM dmx_fixtures), 0),
             CAST(:metadata AS jsonb)
         )
@@ -627,6 +778,7 @@ async def create_fixture(data: DMXFixtureCreate, db: AsyncSession = Depends(get_
         "channel_map": channel_map_json,
         "entity_id": str(data.entity_id) if data.entity_id else None,
         "ofl_fixture_id": data.ofl_fixture_id if data.ofl_fixture_id else None,
+        "group_id": str(data.group_id) if data.group_id else None,
         "position_x": data.position_x,
         "position_y": data.position_y,
         "metadata": metadata_json,
@@ -736,7 +888,7 @@ async def update_fixture(
             elif key == "metadata":
                 set_clauses.append(f"{key} = CAST(:{key} AS jsonb)")
                 params[key] = json.dumps(value)
-            elif key in ("entity_id", "node_id") and value is not None:
+            elif key in ("entity_id", "node_id", "group_id") and value is not None:
                 # UUID fields — store as string; None passes through as NULL below
                 set_clauses.append(f"{key} = :{key}")
                 params[key] = str(value)
@@ -969,6 +1121,7 @@ async def clear_dmx_output(db: AsyncSession = Depends(get_db)):
 
 class DMXCueCreate(BaseModel):
     name: str
+    group_id: Optional[UUID] = None
 
 class DMXCueRename(BaseModel):
     name: str
@@ -980,6 +1133,7 @@ def _row_to_cue(row) -> dict:
         "name": row.name,
         "fade_duration": float(getattr(row, "fade_duration", 0) or 0),
         "sort_order": getattr(row, "sort_order", 0),
+        "group_id": str(row.group_id) if row.group_id else None,
         "created_at": row.created_at.isoformat() if row.created_at else None,
         "updated_at": row.updated_at.isoformat() if row.updated_at else None,
     }
@@ -994,7 +1148,7 @@ async def list_cues(db: AsyncSession = Depends(get_db)):
     denormalized data stored on the cue record itself.
     """
     rows = await db.execute(text("""
-        SELECT id, name, fade_duration, sort_order, created_at, updated_at
+        SELECT id, name, fade_duration, sort_order, group_id, created_at, updated_at
         FROM dmx_cues ORDER BY sort_order ASC, created_at ASC
     """))
     cues = [_row_to_cue(r) for r in rows.fetchall()]
@@ -1037,15 +1191,20 @@ async def list_cues(db: AsyncSession = Depends(get_db)):
 
 @router.post("/cues")
 async def save_cue(data: DMXCueCreate, db: AsyncSession = Depends(get_db)):
-    """Snapshot current entity states for all linked fixtures into a new named cue."""
-    # Collect all fixtures with a linked entity and a channel map
+    """Snapshot current entity states for fixtures in this cue's group into a new named cue.
+
+    If group_id is provided, only fixtures belonging to that group are snapshotted.
+    If group_id is null, only ungrouped fixtures are snapshotted.
+    """
+    # Collect fixtures scoped to the same group as the cue
     fixture_rows = await db.execute(text("""
         SELECT f.id, f.entity_id, f.channel_map
         FROM dmx_fixtures f
         WHERE f.entity_id IS NOT NULL
           AND f.channel_map IS NOT NULL
           AND f.channel_map != '{}'::jsonb
-    """))
+          AND f.group_id IS NOT DISTINCT FROM :group_id
+    """), {"group_id": str(data.group_id) if data.group_id else None})
     fixtures = fixture_rows.fetchall()
 
     # Fetch current entity states in one query
@@ -1060,9 +1219,9 @@ async def save_cue(data: DMXCueCreate, db: AsyncSession = Depends(get_db)):
 
     # Create cue header
     cue_row = await db.execute(text("""
-        INSERT INTO dmx_cues (name) VALUES (:name)
-        RETURNING id, name, created_at, updated_at
-    """), {"name": data.name})
+        INSERT INTO dmx_cues (name, group_id) VALUES (:name, :group_id)
+        RETURNING id, name, group_id, created_at, updated_at
+    """), {"name": data.name, "group_id": str(data.group_id) if data.group_id else None})
     cue = cue_row.fetchone()
 
     import json as _json
@@ -1178,20 +1337,21 @@ async def update_cue_snapshot(cue_id: UUID, db: AsyncSession = Depends(get_db)):
 
     # Verify cue exists
     cue_check = await db.execute(text("""
-        SELECT id, name, fade_duration, sort_order, created_at, updated_at FROM dmx_cues WHERE id = :id
+        SELECT id, name, fade_duration, sort_order, group_id, created_at, updated_at FROM dmx_cues WHERE id = :id
     """), {"id": str(cue_id)})
     cue = cue_check.fetchone()
     if not cue:
         raise HTTPException(status_code=404, detail="Cue not found")
 
-    # Re-snapshot current entity states (same logic as save_cue)
+    # Re-snapshot current entity states scoped to this cue's group
     fixture_rows = await db.execute(text("""
         SELECT f.id, f.entity_id, f.channel_map
         FROM dmx_fixtures f
         WHERE f.entity_id IS NOT NULL
           AND f.channel_map IS NOT NULL
           AND f.channel_map != '{}'::jsonb
-    """))
+          AND f.group_id IS NOT DISTINCT FROM :group_id
+    """), {"group_id": str(cue.group_id) if cue.group_id else None})
     fixtures = fixture_rows.fetchall()
 
     entity_ids = [r.entity_id for r in fixtures]
@@ -1227,7 +1387,7 @@ async def update_cue_snapshot(cue_id: UUID, db: AsyncSession = Depends(get_db)):
     await db.commit()
 
     updated = await db.execute(text("""
-        SELECT id, name, fade_duration, sort_order, created_at, updated_at FROM dmx_cues WHERE id = :id
+        SELECT id, name, fade_duration, sort_order, group_id, created_at, updated_at FROM dmx_cues WHERE id = :id
     """), {"id": str(cue_id)})
     return _row_to_cue(updated.fetchone())
 
@@ -1237,7 +1397,7 @@ async def rename_cue(cue_id: UUID, data: DMXCueRename, db: AsyncSession = Depend
     """Rename a cue."""
     row = await db.execute(text("""
         UPDATE dmx_cues SET name = :name WHERE id = :id
-        RETURNING id, name, fade_duration, sort_order, created_at, updated_at
+        RETURNING id, name, fade_duration, sort_order, group_id, created_at, updated_at
     """), {"name": data.name, "id": str(cue_id)})
     cue = row.fetchone()
     if not cue:
@@ -1281,6 +1441,7 @@ async def get_cue_fixtures(cue_id: UUID, db: AsyncSession = Depends(get_db)):
 
 class DMXSequenceCreate(BaseModel):
     name: str
+    group_id: Optional[UUID] = None
 
 class DMXSequenceRename(BaseModel):
     name: str
@@ -1326,6 +1487,7 @@ def _row_to_sequence(row, placements: list) -> dict:
         "name": row.name,
         "fade_out_duration": float(getattr(row, "fade_out_duration", 3) or 3),
         "sort_order": getattr(row, "sort_order", 0),
+        "group_id": str(row.group_id) if row.group_id else None,
         "created_at": row.created_at.isoformat() if row.created_at else None,
         "updated_at": row.updated_at.isoformat() if row.updated_at else None,
         "cue_placements": placements,
@@ -1336,7 +1498,7 @@ def _row_to_sequence(row, placements: list) -> dict:
 async def list_sequences(db: AsyncSession = Depends(get_db)):
     """List all sequences with their cue placements, ordered by sort_order."""
     seq_rows = await db.execute(text("""
-        SELECT id, name, fade_out_duration, sort_order, created_at, updated_at
+        SELECT id, name, fade_out_duration, sort_order, group_id, created_at, updated_at
         FROM dmx_sequences ORDER BY sort_order ASC, created_at ASC
     """))
     sequences = seq_rows.fetchall()
@@ -1355,10 +1517,10 @@ async def create_sequence(data: DMXSequenceCreate, db: AsyncSession = Depends(ge
     next_order = (max_row.fetchone().m or 0) + 1
 
     row = await db.execute(text("""
-        INSERT INTO dmx_sequences (name, sort_order)
-        VALUES (:name, :sort_order)
-        RETURNING id, name, fade_out_duration, sort_order, created_at, updated_at
-    """), {"name": data.name, "sort_order": next_order})
+        INSERT INTO dmx_sequences (name, sort_order, group_id)
+        VALUES (:name, :sort_order, :group_id)
+        RETURNING id, name, fade_out_duration, sort_order, group_id, created_at, updated_at
+    """), {"name": data.name, "sort_order": next_order, "group_id": str(data.group_id) if data.group_id else None})
     seq = row.fetchone()
     await _sync_dmx_lighting_entity(db)
     await db.commit()
@@ -1382,7 +1544,7 @@ async def rename_sequence(sequence_id: UUID, data: DMXSequenceRename, db: AsyncS
     """Rename a sequence."""
     row = await db.execute(text("""
         UPDATE dmx_sequences SET name = :name WHERE id = :id
-        RETURNING id, name, fade_out_duration, sort_order, created_at, updated_at
+        RETURNING id, name, fade_out_duration, sort_order, group_id, created_at, updated_at
     """), {"name": data.name, "id": str(sequence_id)})
     seq = row.fetchone()
     if not seq:
@@ -1536,17 +1698,24 @@ class PlaybackCueFadeRequest(BaseModel):
 
 
 @router.get("/playback/status")
-async def get_playback_status():
-    """Return current playback engine status."""
-    from dmx_playback_engine import playback_engine
-    return playback_engine.status
+async def get_playback_status(group_id: Optional[str] = None):
+    """Return playback engine status.
+
+    - Omit group_id to get the ungrouped (legacy) engine status (backward compatible).
+    - Pass group_id=<uuid> to get a specific group's engine status.
+    - Pass group_id=all to get all engines' statuses.
+    """
+    from dmx_playback_engine import engine_registry
+    if group_id == "all":
+        return {"engines": engine_registry.all_statuses()}
+    return engine_registry.get(group_id).status
 
 
 @router.get("/playback/config")
 async def get_playback_config():
-    """Return current playback engine configuration."""
-    from dmx_playback_engine import playback_engine
-    return {"interval_ms": round(playback_engine._send_interval * 1000)}
+    """Return current playback engine configuration (shared across all engines)."""
+    from dmx_playback_engine import engine_registry
+    return {"interval_ms": round(engine_registry.ungrouped._send_interval * 1000)}
 
 
 class PlaybackConfigUpdate(BaseModel):
@@ -1556,71 +1725,71 @@ class PlaybackConfigUpdate(BaseModel):
 @router.put("/playback/config")
 async def update_playback_config(data: PlaybackConfigUpdate):
     """Update playback engine configuration at runtime and persist it."""
-    from dmx_playback_engine import playback_engine
-    await playback_engine.set_interval(data.interval_ms)
-    return {"interval_ms": round(playback_engine._send_interval * 1000)}
+    from dmx_playback_engine import engine_registry
+    await engine_registry.ungrouped.set_interval(data.interval_ms)
+    return {"interval_ms": round(engine_registry.ungrouped._send_interval * 1000)}
 
 
 @router.post("/playback/play")
-async def playback_play(data: PlaybackPlayRequest):
-    """Start sequence playback."""
-    from dmx_playback_engine import playback_engine
-    ok = await playback_engine.play(data.sequence_id)
+async def playback_play(data: PlaybackPlayRequest, group_id: Optional[str] = None):
+    """Start sequence playback. Pass group_id to target a specific group's engine."""
+    from dmx_playback_engine import engine_registry
+    ok = await engine_registry.get(group_id).play(data.sequence_id)
     if not ok:
         raise HTTPException(status_code=404, detail="Sequence not found or has no cue placements")
-    return {"status": "playing"}
+    return {"status": "playing", "group_id": group_id}
 
 
 @router.post("/playback/pause")
-async def playback_pause():
+async def playback_pause(group_id: Optional[str] = None):
     """Pause playback."""
-    from dmx_playback_engine import playback_engine
-    await playback_engine.pause()
-    return {"status": "paused"}
+    from dmx_playback_engine import engine_registry
+    await engine_registry.get(group_id).pause()
+    return {"status": "paused", "group_id": group_id}
 
 
 @router.post("/playback/resume")
-async def playback_resume():
+async def playback_resume(group_id: Optional[str] = None):
     """Resume paused playback."""
-    from dmx_playback_engine import playback_engine
-    await playback_engine.resume()
-    return {"status": "playing"}
+    from dmx_playback_engine import engine_registry
+    await engine_registry.get(group_id).resume()
+    return {"status": "playing", "group_id": group_id}
 
 
 @router.post("/playback/stop")
-async def playback_stop():
+async def playback_stop(group_id: Optional[str] = None):
     """Stop playback."""
-    from dmx_playback_engine import playback_engine
-    await playback_engine.stop()
-    return {"status": "stopped"}
+    from dmx_playback_engine import engine_registry
+    await engine_registry.get(group_id).stop()
+    return {"status": "stopped", "group_id": group_id}
 
 
 @router.post("/playback/toggle-loop")
-async def playback_toggle_loop():
+async def playback_toggle_loop(group_id: Optional[str] = None):
     """Toggle loop mode."""
-    from dmx_playback_engine import playback_engine
-    loop = await playback_engine.toggle_loop()
-    return {"loop": loop}
+    from dmx_playback_engine import engine_registry
+    loop = await engine_registry.get(group_id).toggle_loop()
+    return {"loop": loop, "group_id": group_id}
 
 
 @router.post("/playback/fadeout")
-async def playback_fadeout(data: PlaybackFadeOutRequest):
+async def playback_fadeout(data: PlaybackFadeOutRequest, group_id: Optional[str] = None):
     """Fade out dimmer channels of the current cue then stop."""
-    from dmx_playback_engine import playback_engine
-    await playback_engine.fade_out(data.duration_ms)
-    return {"status": "fading_out"}
+    from dmx_playback_engine import engine_registry
+    await engine_registry.get(group_id).fade_out(data.duration_ms)
+    return {"status": "fading_out", "group_id": group_id}
 
 
 @router.post("/playback/cue-fade")
-async def playback_cue_fade(data: PlaybackCueFadeRequest):
+async def playback_cue_fade(data: PlaybackCueFadeRequest, group_id: Optional[str] = None):
     """Fade from one cue snapshot to another."""
-    from dmx_playback_engine import playback_engine
-    ok = await playback_engine.recall_cue_fade(
+    from dmx_playback_engine import engine_registry
+    ok = await engine_registry.get(group_id).recall_cue_fade(
         data.from_cue_id, data.to_cue_id, data.duration_ms
     )
     if not ok:
         raise HTTPException(status_code=404, detail="Target cue has no fixture snapshots")
-    return {"status": "fading"}
+    return {"status": "fading", "group_id": group_id}
 
 
 @router.post("/playback/blackout")

--- a/services/fleet-manager/dmx_router.py
+++ b/services/fleet-manager/dmx_router.py
@@ -32,22 +32,35 @@ _DMX_LIGHTING_SLUG = "dmx-lighting"
 
 
 async def _sync_dmx_lighting_entity(db: AsyncSession) -> None:
-    """Rebuild and persist the DMX Lighting entity state from current cues and sequences.
+    """Rebuild and persist the DMX Lighting entity state from current groups, cues, and sequences.
 
     Executes an UPDATE within the caller's transaction — the caller must commit.
     Safe to call even if the entity does not exist yet (UPDATE is a no-op in that case).
     """
+    group_rows = await db.execute(text("""
+        SELECT id, name, color FROM dmx_groups ORDER BY sort_order ASC, created_at ASC
+    """))
+    groups = [
+        {"id": str(r.id), "name": r.name, "color": r.color}
+        for r in group_rows.fetchall()
+    ]
+
     cue_rows = await db.execute(text("""
-        SELECT id, name, fade_duration, sort_order
+        SELECT id, name, fade_duration, group_id, sort_order
         FROM dmx_cues ORDER BY sort_order ASC, created_at ASC
     """))
     cues = [
-        {"id": str(r.id), "name": r.name, "fade_duration": float(r.fade_duration or 0)}
+        {
+            "id": str(r.id),
+            "name": r.name,
+            "fade_duration": float(r.fade_duration or 0),
+            "group_id": str(r.group_id) if r.group_id else None,
+        }
         for r in cue_rows.fetchall()
     ]
 
     seq_rows = await db.execute(text("""
-        SELECT s.id, s.name, s.fade_out_duration, s.sort_order,
+        SELECT s.id, s.name, s.fade_out_duration, s.group_id, s.sort_order,
                (SELECT COUNT(*) FROM dmx_sequence_cues sc WHERE sc.sequence_id = s.id) AS cue_count
         FROM dmx_sequences s
         ORDER BY s.sort_order ASC, s.created_at ASC
@@ -58,6 +71,7 @@ async def _sync_dmx_lighting_entity(db: AsyncSession) -> None:
             "name": r.name,
             "cue_count": int(r.cue_count),
             "fade_out_duration": float(r.fade_out_duration or 3),
+            "group_id": str(r.group_id) if r.group_id else None,
         }
         for r in seq_rows.fetchall()
     ]
@@ -69,11 +83,29 @@ async def _sync_dmx_lighting_entity(db: AsyncSession) -> None:
     existing = existing_row.fetchone()
     existing_state = (existing.state if existing else {}) or {}
 
+    # Hydrate group_playback from actual engine states so the entity reflects
+    # what is currently playing across all group engines.
+    from dmx_playback_engine import engine_registry
+    group_playback: dict = {}
+    for engine_status in engine_registry.all_statuses():
+        gid = engine_status.get("group_id")
+        if gid is None:
+            # Ungrouped engine — reflected in active_sequence_id / active_cue_id below.
+            continue
+        play_state = engine_status.get("play_state", "stopped")
+        if play_state != "stopped":
+            group_playback[str(gid)] = {
+                "active_sequence_id": engine_status.get("sequence_id"),
+                "active_cue_id": None,
+            }
+
     state = json.dumps({
+        "groups": groups,
         "cues": cues,
         "sequences": sequences,
         "active_cue_id": existing_state.get("active_cue_id"),
         "active_sequence_id": existing_state.get("active_sequence_id"),
+        "group_playback": group_playback,
     })
 
     await db.execute(text("""
@@ -1156,8 +1188,7 @@ async def list_cues(db: AsyncSession = Depends(get_db)):
     if not cues:
         return cues
 
-    # Build node/universe summary per cue in one query
-    cue_ids = [c["id"] for c in cues]
+    # Build node/universe summary per cue in one query (no parameter binding needed)
     node_rows = await db.execute(text("""
         SELECT
             cf.cue_id::text,
@@ -1165,12 +1196,12 @@ async def list_cues(db: AsyncSession = Depends(get_db)):
             n.name       AS node_name,
             f.universe
         FROM dmx_cue_fixtures cf
-        JOIN dmx_fixtures f  ON f.entity_id = cf.entity_id
-        JOIN dmx_nodes    n  ON n.id = f.node_id
-        WHERE cf.cue_id = ANY(:ids)
+        JOIN dmx_cues        c  ON c.id = cf.cue_id
+        JOIN dmx_fixtures    f  ON f.entity_id = CAST(cf.entity_id AS uuid)
+        JOIN dmx_nodes       n  ON n.id = f.node_id
         GROUP BY cf.cue_id, n.id, n.name, f.universe
         ORDER BY n.name, f.universe
-    """), {"ids": [c["id"] for c in cues]})
+    """))
 
     # Aggregate: {cue_id: {node_id: {name, universes: set}}}
     from collections import defaultdict

--- a/services/fleet-manager/entity_router.py
+++ b/services/fleet-manager/entity_router.py
@@ -340,12 +340,14 @@ async def create_entity(
             raise HTTPException(status_code=404, detail="Parent entity not found")
 
     # Generate slug if not provided
+    explicit_slug = bool(entity.slug)
     slug = entity.slug or generate_slug(entity.name)
 
     # Check for duplicate slug
     result = await db.execute(select(EntityDB).where(EntityDB.slug == slug))
     if result.scalar_one_or_none():
-        # Append random suffix
+        if explicit_slug:
+            raise HTTPException(status_code=409, detail=f"Slug '{slug}' is already in use")
         import secrets
         slug = f"{slug}-{secrets.token_hex(3)}"
 

--- a/services/fleet-manager/fixtures_router.py
+++ b/services/fleet-manager/fixtures_router.py
@@ -236,8 +236,13 @@ async def list_fixtures(
     where_clauses = []
 
     if q:
-        where_clauses.append("f.search_vector @@ plainto_tsquery('english', :q)")
+        where_clauses.append(
+            "(f.search_vector @@ plainto_tsquery('english', :q)"
+            " OR f.name ILIKE :q_like"
+            " OR f.fixture_key ILIKE :q_like)"
+        )
         params["q"] = q
+        params["q_like"] = f"%{q}%"
 
     if manufacturer:
         where_clauses.append("f.manufacturer_key = :manufacturer")

--- a/services/fleet-manager/main.py
+++ b/services/fleet-manager/main.py
@@ -33,7 +33,7 @@ from discovery_router import router as discovery_router
 from dmx_router import router as dmx_router
 from fixtures_router import router as fixtures_router
 from osc_mapping_router import router as osc_mapping_router
-from dmx_playback_engine import playback_engine
+from dmx_playback_engine import playback_engine, engine_registry
 from show_control_router import router as show_control_router, handle_show_command
 from show_scheduler import show_scheduler
 
@@ -444,7 +444,7 @@ async def startup_event():
 
     # Load persisted DMX settings (interval, etc.)
     if db_ok:
-        await playback_engine.load_settings()
+        await engine_registry.load_settings()
     # Subscribe NATS for external DMX lighting entity control
     if state_manager.nc:
         async def _on_dmx_lighting_state(msg):
@@ -522,7 +522,7 @@ async def shutdown_event():
     """Cleanup on shutdown"""
     print("👋 Maestra Fleet Manager shutting down...")
     await show_scheduler.stop()
-    await playback_engine.shutdown()
+    await engine_registry.shutdown_all()
     await demo_simulator.stop()
     await cloud_manager.disconnect()
     await stream_manager.disconnect()

--- a/services/fleet-manager/main.py
+++ b/services/fleet-manager/main.py
@@ -453,18 +453,42 @@ async def startup_event():
                 if event.get('source') == 'dmx-engine':
                     return  # Ignore our own broadcasts
                 current_state = event.get('current_state', {}) or {}
-                active_sequence_id = current_state.get('active_sequence_id')
-                active_cue_id = current_state.get('active_cue_id')
+                # changed_keys is set by state_manager on internal updates; external
+                # NATS messages may omit it — treat as "all keys changed" in that case.
+                changed_keys = event.get('changed_keys') or list(current_state.keys())
 
-                if active_sequence_id:
-                    if playback_engine.status['sequence_id'] != active_sequence_id:
-                        await playback_engine.play(active_sequence_id)
-                elif active_cue_id:
-                    prev_cue = playback_engine.status.get('active_cue_id') if playback_engine.status else None
-                    await playback_engine.recall_cue_fade(prev_cue, active_cue_id, 0)
-                else:
-                    if playback_engine.status['play_state'] != 'stopped':
-                        await playback_engine.stop()
+                # ── Ungrouped (legacy) engine ─────────────────────────────────
+                if 'active_sequence_id' in changed_keys or 'active_cue_id' in changed_keys:
+                    active_sequence_id = current_state.get('active_sequence_id')
+                    active_cue_id = current_state.get('active_cue_id')
+                    if active_sequence_id:
+                        if playback_engine.status['sequence_id'] != active_sequence_id:
+                            await playback_engine.play(active_sequence_id)
+                    elif active_cue_id:
+                        prev_cue = playback_engine.status.get('sequence_id')
+                        await playback_engine.recall_cue_fade(prev_cue, active_cue_id, 0)
+                    else:
+                        if playback_engine.status['play_state'] != 'stopped':
+                            await playback_engine.stop()
+
+                # ── Per-group engines ─────────────────────────────────────────
+                # group_playback: {<group_uuid>: {active_sequence_id, active_cue_id}}
+                if 'group_playback' in changed_keys:
+                    group_playback = current_state.get('group_playback') or {}
+                    for group_id, control in group_playback.items():
+                        if not isinstance(control, dict):
+                            continue
+                        grp_engine = engine_registry.get(group_id)
+                        seq_id = control.get('active_sequence_id')
+                        cue_id = control.get('active_cue_id')
+                        if seq_id:
+                            if grp_engine.status['sequence_id'] != seq_id:
+                                await grp_engine.play(seq_id)
+                        elif cue_id:
+                            await grp_engine.recall_cue_fade(None, cue_id, 0)
+                        else:
+                            if grp_engine.status['play_state'] != 'stopped':
+                                await grp_engine.stop()
             except Exception as e:
                 print(f"⚠️ DMX lighting state handler error: {e}")
 

--- a/services/fleet-manager/main.py
+++ b/services/fleet-manager/main.py
@@ -457,13 +457,33 @@ async def startup_event():
                 # NATS messages may omit it — treat as "all keys changed" in that case.
                 changed_keys = event.get('changed_keys') or list(current_state.keys())
 
+                def _parse_seq_control(value):
+                    """Parse active_sequence_id which can be:
+                    - None/null  → stop
+                    - str        → play once, stop on last values
+                    - dict       → {id, loop?, fadeout?}  (fadeout in seconds)
+                    Returns (seq_id, loop, fadeout_ms).
+                    """
+                    if value is None:
+                        return None, False, None
+                    if isinstance(value, str):
+                        return value, False, None
+                    if isinstance(value, dict):
+                        seq_id = value.get('id')
+                        loop = bool(value.get('loop', False))
+                        fadeout_s = value.get('fadeout')
+                        fadeout_ms = float(fadeout_s) * 1000.0 if fadeout_s is not None else None
+                        return seq_id, loop, fadeout_ms
+                    return None, False, None
+
                 # ── Ungrouped (legacy) engine ─────────────────────────────────
                 if 'active_sequence_id' in changed_keys or 'active_cue_id' in changed_keys:
-                    active_sequence_id = current_state.get('active_sequence_id')
+                    raw_seq = current_state.get('active_sequence_id')
                     active_cue_id = current_state.get('active_cue_id')
-                    if active_sequence_id:
-                        if playback_engine.status['sequence_id'] != active_sequence_id:
-                            await playback_engine.play(active_sequence_id)
+                    seq_id, loop, fadeout_ms = _parse_seq_control(raw_seq)
+                    if seq_id:
+                        if playback_engine.status['sequence_id'] != seq_id:
+                            await playback_engine.play(seq_id, loop=loop, fadeout_ms=fadeout_ms)
                     elif active_cue_id:
                         prev_cue = playback_engine.status.get('sequence_id')
                         await playback_engine.recall_cue_fade(prev_cue, active_cue_id, 0)
@@ -479,11 +499,12 @@ async def startup_event():
                         if not isinstance(control, dict):
                             continue
                         grp_engine = engine_registry.get(group_id)
-                        seq_id = control.get('active_sequence_id')
+                        raw_seq = control.get('active_sequence_id')
                         cue_id = control.get('active_cue_id')
+                        seq_id, loop, fadeout_ms = _parse_seq_control(raw_seq)
                         if seq_id:
                             if grp_engine.status['sequence_id'] != seq_id:
-                                await grp_engine.play(seq_id)
+                                await grp_engine.play(seq_id, loop=loop, fadeout_ms=fadeout_ms)
                         elif cue_id:
                             await grp_engine.recall_cue_fade(None, cue_id, 0)
                         else:


### PR DESCRIPTION
## Summary

This PR delivers a full upgrade to the DMX Lighting feature set: independent per-group playback engines, advanced sequence control parameters, a richer entity state schema, and several UX and bug fixes.

---

### DMX Groups (Layers)

- **Group management** — Create, rename, recolor, reorder, and delete groups from the sidebar Groups tab. Each group has an independent playback engine with LTP merge semantics.
- **Fixture assignment** — Select a group, then shift-click fixtures on the canvas to add or remove them. Fixtures in a different group are dimmed and cannot be assigned.
- **Canvas group mode** — Three visual states: bright colored ring (in group), faint dashed ring (eligible), dimmed with no-drop cursor (in another group). Read-only highlight shown in Cues/Sequences tabs.
- **Group context pills** — Cues and Sequences tabs each show a pill bar to filter content by group. Clicking **All** shows everything.
- **Cues and sequences belong to groups** — Saved cues and sequences can be associated with a group. When adding cues to a sequence, only cues from the same group are offered.
- **Migration** — `018_dmx_groups.sql` adds the `dmx_groups` table and `group_id` FK columns on cues, sequences, and fixtures.

### Multi-Group Simultaneous Playback

- **Independent engines** — `DMXEngineRegistry` manages a singleton per group key (`None` = ungrouped, UUID string = per-group). Sequences on different groups run concurrently and never interrupt each other.
- **`useSequencePlayback` redesign** — Hook now tracks a `Map<groupId, SequencePlaybackStatus>` instead of a single status. Polls `GET /dmx/playback/status?group_id=all` every 150ms; stops when all engines idle.
- **`activeGroupIds` set** — `useMemo`-derived set of group IDs with non-stopped engines; drives green pulse indicators across the UI.
- **Green pulse indicators** — Active engine state is shown on group rows (Groups tab), context pills (Cues and Sequences tabs), the Sequences tab header, and per-sequence play controls.

### Sequence Playback Control Parameters

`active_sequence_id` in the entity state (both top-level and inside `group_playback`) now accepts a plain string UUID **or** a control object:

```json
{ "id": "<sequence-uuid>", "loop": true }
{ "id": "<sequence-uuid>", "fadeout": 3.0 }
```

- **Plain string** — plays once; last DMX values hold when the final cue completes
- **`loop: true`** — sequence repeats indefinitely
- **`fadeout: N`** — after the final cue, fades all dimmer/intensity channels to zero over N seconds, then stops
- `POST /dmx/playback/play` accepts the same options via `loop` (bool) and `fadeout_ms` (float) fields
- `_parse_seq_control()` helper in `main.py` cleanly handles `None`, string, and dict inputs
- Migration `020_dmx_lighting_seq_control_schema.sql` documents the `oneOf` schema in the entity type

### DMX Lighting Entity Schema

The `dmx-lighting` singleton entity state now includes:

```json
{
  "groups": [{ "id": "...", "name": "...", "color": "..." }],
  "cues": [{ "id": "...", "name": "...", "fade_duration": 0, "group_id": null }],
  "sequences": [{ "id": "...", "name": "...", "cue_count": 0, "fade_out_duration": 3, "group_id": null }],
  "active_cue_id": null,
  "active_sequence_id": null,
  "group_playback": {
    "<group-uuid>": { "active_sequence_id": null, "active_cue_id": null }
  }
}
```

- `group_playback` is hydrated from the live engine registry on every catalog sync so external tools can read current playback state per group
- Migration `019_dmx_lighting_groups_state.sql` patches the existing singleton and updates the entity type schema

### Bug Fix — Active Cue Deselect Not Syncing to Entity State

- Clicking an already-active cue in the sidebar to deselect it previously only cleared local UI state — `active_cue_id` in the entity remained set
- Fixed by storing the DMX lighting entity UUID in a ref on page mount and calling `PATCH /entities/{id}/state` with `{ active_cue_id: null }` on toggle-off

### Additional UX Improvements

- **Blackout button** — instantly zeros all DMX channels across all universes without pausing; double-click to blackout and pause simultaneously
- **Cue recall auto-resume** — recalling a cue while output is paused automatically resumes, since cue recall is an intentional fire action
- **Fixture slug** — fixtures now have a stable slug for entity linking
- **Cue universe display** — cue rows show which universe each fixture snapshot belongs to
- **Double-click to edit** — double-click a fixture on the canvas to open DMX Adjust directly

### Docs

`docs/docs/guides/dmx-gateway.md` fully updated:
- Groups section: canvas visual states, shift-click assignment, group list UI, pulse indicators
- Cues/Sequences sections: group context pills, simultaneous playback, per-group filtering
- DMX Lighting Entity: new state shape, `active_sequence_id` string/object options table, ungrouped and per-group control examples for all three parameter forms
- REST API: Groups endpoints table, updated Playback section with `loop`/`fadeout_ms` play request fields and `?group_id=all` status response

## Test plan

- [ ] Create two groups, assign different fixtures to each, save a sequence per group — verify both play simultaneously without interfering
- [ ] Play a sequence with `loop: true` via entity state PATCH — verify it repeats
- [ ] Play a sequence with `fadeout: 3` — verify DMX fades to zero ~3 seconds after the last cue, then engine stops
- [ ] Play a sequence with a plain UUID string — verify last values hold on completion
- [ ] Recall a cue, then click it again to deselect — verify `active_cue_id` is `null` in the entity state
- [ ] Verify `GET /dmx/playback/status?group_id=all` returns all active engines
- [ ] Green pulse dots appear on group rows, pills, and Sequences header when engines are active

🤖 Generated with [Claude Code](https://claude.com/claude-code)