### PR TITLE
feat: mobile-responsive interface, entity display name editing, DMX fixture name sync

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,4 +1,4 @@
 [submodule "vendor/ofl"]
 	path = vendor/ofl
 	url = https://github.com/aarongeiser/open-fixture-library.git
-	branch = branch2026-03-23T04-51-04
+	branch = master

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -582,6 +582,7 @@ The `dmx-lighting` singleton entity (slug `dmx-lighting`, type `dmx_controller`)
 - **Green pulse indicators**: active sequence engines shown on group rows, context pills, Sequences tab header
 - **`useSequencePlayback` hook**: tracks `Map<string|null, SequencePlaybackStatus>` keyed by `group_id`; `activeGroupIds` useMemo set drives all visual indicators; polls every 150ms while any engine is active
 - **`onAdjustFixture` prop**: mobile-specific path to open the DMX channel modal for a specific fixture without requiring canvas selection
+- **DMX Adjust Modal** (`DMXChannelModal.tsx`): vertical channel sliders (`0–255`) for each channel in the fixture's channel map; when both `pan` and `tilt` channels are detected a segmented toggle in the header switches to **Pan/Tilt joystick mode** — a 2D drag pad (mouse + touch) with a Center button; both modes write through `handleChange` → `entitiesApi.updateState` with 50ms debounce; touch listeners added imperatively with `{ passive: false }` so drag doesn't scroll the page
 
 ## Configuration
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -178,6 +178,10 @@ Located at `services/fleet-manager/main.py`:
   - Optional API key auth via `SHOW_CONTROL_TOKEN` env var
   - Inbound commands via NATS: `maestra.show.command.*` and `maestra.osc.show.*`
   - Background scheduler evaluates cron entries every 60 seconds
+- **DMX Lighting**: Full Art-Net / DMX512 fixture control (see DMX Lighting System section below)
+  - Router: `services/fleet-manager/dmx_router.py`
+  - Playback engine: `services/fleet-manager/dmx_playback_engine.py`
+  - NATS state handler and entity sync in `services/fleet-manager/main.py`
 - API docs at http://localhost:8080/docs
 
 ### Dashboard (Next.js)
@@ -186,6 +190,26 @@ Located at `services/dashboard/`:
 - Next.js 14 with React 18
 - TailwindCSS, Recharts, Socket.IO, MQTT
 - Environment vars in `NEXT_PUBLIC_*` prefix
+
+**Responsive design system** (`services/dashboard/src/app/globals.css` + `tailwind.config.js`):
+- CSS custom properties define single-source-of-truth design tokens:
+  - `--sidebar-nav-width: 14rem` — left navigation sidebar width
+  - `--sidebar-dmx-width: 295px` — DMX Lighting right sidebar width
+  - `--z-nav-backdrop: 40`, `--z-overlay: 50` — z-index layers
+  - `--breakpoint-mobile: 768px` — documents the `md` Tailwind breakpoint
+- Tailwind `theme.extend.width` adds `w-sidebar-nav` and `w-sidebar-dmx` utilities backed by the CSS vars
+- `@layer components` defines shared classes:
+  - `.modal-backdrop` — `fixed inset-0 z-50` centered flex with `p-4` safe padding and `bg-black/60 backdrop-blur-sm`; pair with `.modal-panel max-w-sm` or `.modal-panel max-w-lg`
+  - `.modal-panel` — base modal frame (`w-full bg-slate-900 border border-slate-700 rounded-xl shadow-2xl`); caller adds size and layout modifiers
+  - `.nav-overlay-backdrop` — mobile-only (`md:hidden`) nav backdrop at `z-40`
+
+**Mobile layout** (breakpoint `md` = 768px):
+- `AppShell`: mobile top bar (`md:hidden`) with hamburger button (opens slide-in nav), Maestra wordmark, and system health status dots on the right
+- `Sidebar`: fixed overlay on mobile (`translate-x` open/close, 300ms ease), static in flexbox on desktop; uses `w-sidebar-nav`
+- Nav links call `onClose()` to dismiss the drawer on mobile
+- System health dots in the top bar come from `useSystemHealth(30000)` + `useWebSocket()` called in AppShell
+- Dashboard page has a mobile toggle button (`md:hidden`) to switch between the dashboard summary view and the Live Activity feed full-screen view
+- DMX Lighting page: canvas is `hidden md:block` on mobile; DMX sidebar becomes full-width (`w-full md:w-sidebar-dmx`); toolbar labels condensed to icon-only on small screens; scale picker hidden; per-fixture Adjust button always visible (not hover-only)
 
 ### Message Envelope Convention
 
@@ -467,6 +491,97 @@ All 8 SDKs support streams:
 - **Arduino**: MQTT-only stream events (advertise, subscribe, heartbeat via pub/sub topics)
 - **Processing**: MQTT-based with `processing-mqtt` (Eclipse Paho), thread-safe queue for main-thread dispatch
 - **OpenFrameworks**: MQTT-based `ofxMaestra` addon with `ofxMQTT` (libmosquitto), main-thread callbacks via `ofEvent`
+
+## DMX Lighting System
+
+The DMX Lighting feature provides Art-Net/DMX512 fixture control with a full cue/sequence programming interface. It is configured entirely through the Dashboard UI or the Fleet Manager REST API — no YAML files.
+
+### Database Tables
+
+| Table | Migration | Purpose |
+|-------|-----------|---------|
+| `dmx_nodes` | init | Art-Net hardware nodes (IP, universes) |
+| `dmx_fixtures` | init | Fixture patch (node, universe, start channel, channel map, entity link) |
+| `dmx_groups` | 018 | Independent playback layers; fixtures, cues, and sequences belong to a group |
+| `dmx_cues` | init | Named snapshots of fixture states; optional `group_id` |
+| `dmx_sequences` | init | Ordered cue chains with transition/hold timing; optional `group_id` |
+| `dmx_cue_placements` | init | Many-to-many cue↔sequence with `transition_time` and `hold_duration` |
+| `dmx_fixture_snapshots` | init | Fixture state data stored per cue |
+
+### Playback Engine Architecture
+
+`DMXGroupEngine` (`dmx_playback_engine.py`) — one instance per group (and one ungrouped):
+- Ticks every 80ms; interpolates DMX values between cues during transitions
+- States: `stopped → playing → paused`; phases: `idle → transitioning → holding`
+- Supports `loop` (repeat sequence indefinitely) and `fadeout_ms` (fade dimmers to zero on completion)
+- `play(sequence_id, loop=False, fadeout_ms=None)` — starts playback; stores parameters
+- `_fadeout_ms_on_complete` — fires `_run_fade_out()` as a background task on non-looping completion
+
+`DMXEngineRegistry` — singleton dict in `dmx_router.py`:
+- Key `None` → ungrouped (legacy) engine
+- Key `"<group-uuid>"` → per-group engine
+- Groups run fully independently; playing a sequence on group A never affects group B
+- `GET /dmx/playback/status?group_id=all` returns all active engines in one request
+
+### Entity State Integration
+
+The `dmx-lighting` singleton entity (slug `dmx-lighting`, type `dmx_controller`) reflects the full catalog and enables external control from any Maestra client:
+
+```json
+{
+  "groups":   [{ "id": "uuid", "name": "Stage Left", "color": "#ef4444" }],
+  "cues":     [{ "id": "uuid", "name": "Warm Stage", "fade_duration": 2.5, "group_id": "uuid|null" }],
+  "sequences":[{ "id": "uuid", "name": "Opening", "cue_count": 4, "fade_out_duration": 3.0, "group_id": "uuid|null" }],
+  "active_cue_id": null,
+  "active_sequence_id": null,
+  "group_playback": {
+    "<group-uuid>": { "active_sequence_id": null, "active_cue_id": null }
+  }
+}
+```
+
+`_sync_dmx_lighting_entity()` in `dmx_router.py` — called after every CRUD operation; rebuilds the full entity state from the database and hydrates `group_playback` from the live engine registry.
+
+`_on_dmx_lighting_state()` in `main.py` — NATS handler for `maestra.entity.state.update.dmx-lighting`; routes state changes to the correct engine(s).
+
+### Sequence Control Parameters
+
+`active_sequence_id` (and the equivalent field inside each `group_playback` entry) accepts a plain string UUID **or** a control object:
+
+| Form | Behavior |
+|------|----------|
+| `"<uuid>"` | Play once; last DMX values hold when the final cue completes |
+| `{"id": "<uuid>", "loop": true}` | Repeat indefinitely |
+| `{"id": "<uuid>", "fadeout": 3.0}` | Fade dimmers to zero over N seconds on completion, then stop |
+
+`_parse_seq_control(value)` in `main.py` — handles `None`, string, and dict inputs uniformly; returns `(seq_id, loop, fadeout_ms)`.
+
+`POST /dmx/playback/play` accepts the same options via `loop` (bool) and `fadeout_ms` (float) fields.
+
+### Key Implementation Files
+
+| File | Purpose |
+|------|---------|
+| `services/fleet-manager/dmx_router.py` | All DMX REST endpoints + `DMXEngineRegistry` + `_sync_dmx_lighting_entity()` |
+| `services/fleet-manager/dmx_playback_engine.py` | `DMXGroupEngine` — tick loop, transitions, fade-out |
+| `services/fleet-manager/main.py` | `_on_dmx_lighting_state()` NATS handler, `_parse_seq_control()` |
+| `services/dmx-gateway/main.py` | Art-Net UDP sender; reads fixture config from Fleet Manager API |
+| `config/postgres/migrations/018_dmx_groups.sql` | Groups table + `group_id` FK columns on fixtures, cues, sequences |
+| `config/postgres/migrations/019_dmx_lighting_groups_state.sql` | Updates `dmx_controller` entity type schema with groups/group_playback |
+| `config/postgres/migrations/020_dmx_lighting_seq_control_schema.sql` | Documents `oneOf` string/object schema for `active_sequence_id` |
+| `services/dashboard/src/app/dmx/page.tsx` | DMX Lighting page — canvas, toolbar, all modal handlers |
+| `services/dashboard/src/components/dmx/DMXSidebar.tsx` | Right sidebar — 5 tabs: Nodes, Fixtures, Groups, Cues, Sequences |
+| `services/dashboard/src/components/dmx/DMXCanvas.tsx` | Drag-and-drop fixture layout canvas |
+| `services/dashboard/src/hooks/useSequencePlayback.ts` | Multi-group playback state; polls `?group_id=all`; exports `Map<groupId, status>` |
+
+### Dashboard DMX UI Patterns
+
+- **5-tab sidebar** (`DMXSidebar.tsx`): Nodes, Fixtures, Groups, Cues, Sequences — accordion-style with `gridTemplateRows` animation; active section remembered in `sessionStorage`
+- **Group context pills**: Cues and Sequences tabs each show a group filter pill bar; `cueGroupId` drives canvas highlight independently of `selectedGroupId` (Groups tab)
+- **Canvas group mode**: three visual states — in-group (bright ring), eligible (dashed), ineligible (dimmed); shift-click toggles fixture membership
+- **Green pulse indicators**: active sequence engines shown on group rows, context pills, Sequences tab header
+- **`useSequencePlayback` hook**: tracks `Map<string|null, SequencePlaybackStatus>` keyed by `group_id`; `activeGroupIds` useMemo set drives all visual indicators; polls every 150ms while any engine is active
+- **`onAdjustFixture` prop**: mobile-specific path to open the DMX channel modal for a specific fixture without requiring canvas selection
 
 ## Configuration
 

--- a/config/postgres/migrations/021_drop_dmx_fixture_label.sql
+++ b/config/postgres/migrations/021_drop_dmx_fixture_label.sql
@@ -1,0 +1,6 @@
+-- Remove the label (short label) column from dmx_fixtures.
+-- The field is no longer used by the dashboard or API; fixture names
+-- are now the sole display identifier for DMX fixtures.
+-- Safe to run on databases that have already had the column removed.
+
+ALTER TABLE dmx_fixtures DROP COLUMN IF EXISTS label;

--- a/docs/docs/guides/dashboard.md
+++ b/docs/docs/guides/dashboard.md
@@ -17,7 +17,7 @@ The **Entities** page shows every entity in your project. Click any entity to se
 
 ### Create and edit entities
 
-Click **+ Create Entity** to add a new entity. Give it a name, choose a type, and optionally set some initial state values. You can also edit existing entities — change their name, type, or state directly from the browser.
+Click **+ Create Entity** to add a new entity. Give it a name, choose a type, and optionally set some initial state values. You can also edit existing entities — change their display name, type, or state directly from the browser. The entity's slug (used as its API and message-bus identifier) is set at creation time and does not change when you rename it.
 
 ### Watch live state changes
 

--- a/docs/docs/guides/dmx-gateway.md
+++ b/docs/docs/guides/dmx-gateway.md
@@ -227,9 +227,11 @@ A green pulse dot appears on the Sequences tab header when any group engine is a
 
 #### DMX Adjust Modal
 
-Select one or more fixtures on the canvas, then click **Adjust DMX** (toolbar or context menu) to open the channel slider panel. Each channel from the fixture's channel map is shown as a labeled slider (`0–255`). Changes are sent to the linked entity in real time.
+Select one or more fixtures on the canvas, then click **Adjust DMX** (toolbar or context menu) to open the channel slider panel. Each channel from the fixture's channel map is shown as a labeled vertical slider (`0–255`). Changes are sent to the linked entity in real time.
 
 Multi-selected fixtures of the same OFL model and universe can be adjusted simultaneously.
+
+**Pan/Tilt Joystick mode** — When the fixture's channel map includes both a `pan` and `tilt` channel, a toggle appears in the modal header to switch between the standard channel sliders and a 2D joystick pad. The joystick maps the X axis to Pan and the Y axis to Tilt; drag with a mouse on desktop or use touch on mobile. A **Center** button snaps both channels to 127. Values update in real time using the same entity state pipeline as the individual sliders.
 
 #### Add / Edit Fixture Modal
 
@@ -240,7 +242,7 @@ When adding a fixture you can:
 4. Choose the Art-Net node, universe, and start channel
 5. Optionally link to an existing Maestra entity (or let the system auto-create one)
 
-Editing an existing fixture uses the same form. Deleting a fixture optionally deletes its linked entity as well.
+Editing an existing fixture uses the same form. When you change a fixture's name, its linked entity's display name is automatically updated to match. Deleting a fixture optionally deletes its linked entity as well.
 
 #### Art-Net Node Setup
 
@@ -636,7 +638,7 @@ make sync-ofl
 
 ## Open Fixture Library Integration
 
-Maestra ships the [Open Fixture Library](https://open-fixture-library.org/) as a git submodule and syncs it into the `ofl_manufacturers` and `ofl_fixtures` tables. When you add a fixture in the Dashboard, you can search manufacturers and models; the channel map is auto-generated from the OFL fixture definition and the selected mode.
+Maestra ships the [Open Fixture Library](https://open-fixture-library.org/) as a git submodule (tracking the `master` branch) and syncs it into the `ofl_manufacturers` and `ofl_fixtures` tables. When you add a fixture in the Dashboard, you can search manufacturers and models; the channel map is auto-generated from the OFL fixture definition and the selected mode.
 
 The OFL catalog is **never synced automatically** — run `make sync-ofl` manually to pull the latest fixture definitions. Check sync status with `make ofl-status` or `GET /ofl/sync/status`.
 

--- a/docs/plans/ofl-git-sync-integration-plan.md
+++ b/docs/plans/ofl-git-sync-integration-plan.md
@@ -139,7 +139,7 @@ Because Maestra must work offline at venues, fixture data cannot be fetched at r
 
 ```bash
 # From maestra-core project root
-git submodule add https://github.com/OpenLightingProject/open-fixture-library.git vendor/ofl
+git submodule add -b master https://github.com/aarongeiser/open-fixture-library.git vendor/ofl
 git submodule update --init --depth 1
 ```
 

--- a/services/dashboard/src/app/dmx/page.tsx
+++ b/services/dashboard/src/app/dmx/page.tsx
@@ -502,22 +502,22 @@ export default function DMXPage() {
   return (
     <div className="h-full flex flex-col overflow-hidden">
       {/* Toolbar */}
-      <div className="flex items-center justify-between px-4 py-2.5 bg-slate-900 border-b border-slate-800 shrink-0">
-        <div className="flex items-center gap-2">
-          <Zap className="w-4 h-4 text-amber-400" />
-          <span className="text-sm font-semibold text-white">DMX Lighting</span>
-          <span className="text-xs text-slate-600">
+      <div className="flex items-center justify-between px-3 md:px-4 py-2.5 bg-slate-900 border-b border-slate-800 shrink-0 gap-2">
+        <div className="flex items-center gap-2 min-w-0">
+          <Zap className="w-4 h-4 text-amber-400 shrink-0" />
+          <span className="text-sm font-semibold text-white shrink-0">DMX Lighting</span>
+          <span className="text-xs text-slate-600 hidden sm:inline">
             {fixtures.length} fixture{fixtures.length !== 1 ? 's' : ''} · {nodes.length} node{nodes.length !== 1 ? 's' : ''}
           </span>
           {syncStatus && (
-            <span className="text-xs text-slate-600 ml-2 pl-2 border-l border-slate-800">
+            <span className="text-xs text-slate-600 ml-2 pl-2 border-l border-slate-800 hidden lg:inline">
               OFL synced {formatRelativeTime(syncStatus.ran_at)}
             </span>
           )}
         </div>
-        <div className="flex items-center gap-2">
+        <div className="flex items-center gap-2 shrink-0">
           {actionError && (
-            <span className="text-xs text-red-400">{actionError}</span>
+            <span className="text-xs text-red-400 hidden sm:inline">{actionError}</span>
           )}
 
           {/* DMX Pause / Resume / Clear */}
@@ -525,34 +525,34 @@ export default function DMXPage() {
             <button
               onClick={handleTogglePause}
               disabled={pauseLoading}
-              className={`flex items-center gap-1.5 px-3 py-1.5 text-xs font-medium transition-colors disabled:opacity-50 ${
+              className={`flex items-center gap-1.5 px-2.5 md:px-3 py-1.5 text-xs font-medium transition-colors disabled:opacity-50 ${
                 isPaused
                   ? 'bg-amber-500/20 text-amber-300 hover:bg-amber-500/30'
                   : 'bg-slate-800 text-slate-400 hover:text-slate-200'
               }`}
             >
               {isPaused
-                ? <><Play className="w-3 h-3" /> Resume Listening</>
-                : <><Pause className="w-3 h-3" /> Pause</>
+                ? <><Play className="w-3 h-3" /><span className="hidden sm:inline ml-1">Resume</span></>
+                : <><Pause className="w-3 h-3" /><span className="hidden sm:inline ml-1">Pause</span></>
               }
             </button>
             {isPaused && (
-              <>
-                <button
-                  onClick={() => setShowClearConfirm(true)}
-                  disabled={clearLoading}
-                  className="flex items-center gap-1.5 px-3 py-1.5 text-xs font-medium text-red-400 bg-slate-800 hover:bg-red-900/30 hover:text-red-300 transition-colors disabled:opacity-50"
-                >
-                  <Trash2 className="w-3 h-3" />
-                  Clear
-                </button>
-              </>
+              <button
+                onClick={() => setShowClearConfirm(true)}
+                disabled={clearLoading}
+                className="flex items-center gap-1.5 px-2.5 md:px-3 py-1.5 text-xs font-medium text-red-400 bg-slate-800 hover:bg-red-900/30 hover:text-red-300 transition-colors disabled:opacity-50"
+              >
+                <Trash2 className="w-3 h-3" />
+                <span className="hidden sm:inline">Clear</span>
+              </button>
             )}
           </div>
+
+          {/* Paused badge — icon-only on mobile */}
           {isPaused && (
-            <span className="flex items-center gap-1.5 text-xs font-medium text-amber-400 bg-amber-500/10 border border-amber-500/30 px-2.5 py-1.5 rounded-lg">
+            <span className="flex items-center gap-1.5 text-xs font-medium text-amber-400 bg-amber-500/10 border border-amber-500/30 px-2 md:px-2.5 py-1.5 rounded-lg">
               <span className="w-1.5 h-1.5 rounded-full bg-amber-400 animate-pulse shrink-0" />
-              External signals paused
+              <span className="hidden md:inline">External signals paused</span>
             </span>
           )}
 
@@ -561,14 +561,14 @@ export default function DMXPage() {
             onClick={() => playbackApi.blackout().catch(() => {})}
             onDoubleClick={(e) => { e.preventDefault(); handleBlackoutAndPause() }}
             title="Blackout — double-click to blackout and pause"
-            className="flex items-center gap-1.5 px-3 py-1.5 text-xs font-medium rounded-lg border border-slate-700 bg-slate-800 text-slate-400 hover:text-yellow-300 hover:border-yellow-700/50 hover:bg-yellow-900/20 transition-colors"
+            className="flex items-center gap-1.5 px-2.5 md:px-3 py-1.5 text-xs font-medium rounded-lg border border-slate-700 bg-slate-800 text-slate-400 hover:text-yellow-300 hover:border-yellow-700/50 hover:bg-yellow-900/20 transition-colors"
           >
             <ZapOff className="w-3 h-3" />
-            Blackout
+            <span className="hidden sm:inline">Blackout</span>
           </button>
 
-          {/* Node scale picker */}
-          <div className="flex items-center rounded-lg overflow-hidden border border-slate-700">
+          {/* Node scale picker — desktop only (no canvas on mobile) */}
+          <div className="hidden md:flex items-center rounded-lg overflow-hidden border border-slate-700">
             {NODE_SCALES.map((scale) => (
               <button
                 key={scale.label}
@@ -588,7 +588,8 @@ export default function DMXPage() {
 
       {/* Canvas + sidebar */}
       <div className="flex-1 flex overflow-hidden">
-        <div className="flex-1 min-w-0">
+        {/* Canvas — hidden on mobile */}
+        <div className="hidden md:block flex-1 min-w-0">
           <DMXCanvas
             fixtures={fixtures}
             nodes={nodes}
@@ -668,12 +669,16 @@ export default function DMXPage() {
           openSequencesSignal={openSequencesSignal}
           availableCues={cues}
           onCreateSequence={handleCreateSequence}
+          onAdjustFixture={(fixture) => {
+            setSelectedIds(new Set([fixture.id]))
+            setShowDMXAdjust(true)
+          }}
         />
       </div>
 
       {/* Add Node Modal */}
       {showAddNode && (
-        <div className="fixed inset-0 z-50 flex items-center justify-center bg-black/60 backdrop-blur-sm">
+        <div className="fixed inset-0 z-50 flex items-center justify-center bg-black/60 backdrop-blur-sm p-4">
           <div className="w-full max-w-lg bg-slate-900 border border-slate-700 rounded-xl shadow-2xl">
             <div className="flex items-center justify-between px-5 py-4 border-b border-slate-800">
               <div className="flex items-center gap-2">
@@ -699,7 +704,7 @@ export default function DMXPage() {
 
       {/* Edit Node Modal */}
       {editingNode && (
-        <div className="fixed inset-0 z-50 flex items-center justify-center bg-black/60 backdrop-blur-sm">
+        <div className="fixed inset-0 z-50 flex items-center justify-center bg-black/60 backdrop-blur-sm p-4">
           <div className="w-full max-w-lg bg-slate-900 border border-slate-700 rounded-xl shadow-2xl">
             <div className="flex items-center justify-between px-5 py-4 border-b border-slate-800">
               <div className="flex items-center gap-2">

--- a/services/dashboard/src/app/dmx/page.tsx
+++ b/services/dashboard/src/app/dmx/page.tsx
@@ -678,8 +678,8 @@ export default function DMXPage() {
 
       {/* Add Node Modal */}
       {showAddNode && (
-        <div className="fixed inset-0 z-50 flex items-center justify-center bg-black/60 backdrop-blur-sm p-4">
-          <div className="w-full max-w-lg bg-slate-900 border border-slate-700 rounded-xl shadow-2xl">
+        <div className="modal-backdrop">
+          <div className="modal-panel max-w-lg">
             <div className="flex items-center justify-between px-5 py-4 border-b border-slate-800">
               <div className="flex items-center gap-2">
                 <Network className="w-4 h-4 text-blue-400" />
@@ -704,8 +704,8 @@ export default function DMXPage() {
 
       {/* Edit Node Modal */}
       {editingNode && (
-        <div className="fixed inset-0 z-50 flex items-center justify-center bg-black/60 backdrop-blur-sm p-4">
-          <div className="w-full max-w-lg bg-slate-900 border border-slate-700 rounded-xl shadow-2xl">
+        <div className="modal-backdrop">
+          <div className="modal-panel max-w-lg">
             <div className="flex items-center justify-between px-5 py-4 border-b border-slate-800">
               <div className="flex items-center gap-2">
                 <Network className="w-4 h-4 text-blue-400" />
@@ -873,8 +873,8 @@ export default function DMXPage() {
 
       {/* Delete Sequence Confirmation */}
       {deleteSequenceTarget && (
-        <div className="fixed inset-0 z-50 flex items-center justify-center bg-black/70 backdrop-blur-sm">
-          <div className="w-full max-w-sm bg-slate-900 border border-slate-700 rounded-xl shadow-2xl">
+        <div className="modal-backdrop">
+          <div className="modal-panel max-w-sm">
             <div className="flex items-center gap-3 px-5 py-4 border-b border-slate-800">
               <div className="w-8 h-8 rounded-full bg-red-900/40 border border-red-800/50 flex items-center justify-center shrink-0">
                 <Trash2 className="w-4 h-4 text-red-400" />
@@ -899,8 +899,8 @@ export default function DMXPage() {
 
       {/* Clear DMX Confirmation */}
       {showClearConfirm && (
-        <div className="fixed inset-0 z-50 flex items-center justify-center bg-black/70 backdrop-blur-sm">
-          <div className="w-full max-w-sm bg-slate-900 border border-slate-700 rounded-xl shadow-2xl">
+        <div className="modal-backdrop">
+          <div className="modal-panel max-w-sm">
             <div className="flex items-center gap-3 px-5 py-4 border-b border-slate-800">
               <div className="w-8 h-8 rounded-full bg-red-900/40 border border-red-800/50 flex items-center justify-center shrink-0">
                 <AlertTriangle className="w-4 h-4 text-red-400" />

--- a/services/dashboard/src/app/entities/[id]/page.tsx
+++ b/services/dashboard/src/app/entities/[id]/page.tsx
@@ -221,7 +221,7 @@ export default function EntityDetailPage() {
   )
   const filteredFixtures = linkableFixtures.filter((f) => {
     const q = fixtureSearch.toLowerCase()
-    return !q || f.name.toLowerCase().includes(q) || (f.label ?? '').toLowerCase().includes(q)
+    return !q || f.name.toLowerCase().includes(q)
   })
 
   const channelMapEntries = linkedFixture
@@ -364,12 +364,6 @@ export default function EntityDetailPage() {
                     <span className="text-slate-500">Fixture</span>
                     <span className="text-slate-200 font-medium">{linkedFixture.name}</span>
                   </div>
-                  {linkedFixture.label && (
-                    <div className="flex justify-between">
-                      <span className="text-slate-500">Label</span>
-                      <span className="text-slate-300">{linkedFixture.label}</span>
-                    </div>
-                  )}
                   <div className="flex justify-between">
                     <span className="text-slate-500">Universe</span>
                     <span className="text-slate-300 font-mono">U{linkedFixture.universe}</span>
@@ -488,7 +482,10 @@ export default function EntityDetailPage() {
               {editing ? (
                 <div className="space-y-4">
                   <div>
-                    <label className="block text-sm font-medium mb-1">Name</label>
+                    <label className="block text-sm font-medium mb-1">
+                      Display Name
+                      <span className="ml-2 text-xs font-normal text-slate-500">slug stays unchanged</span>
+                    </label>
                     <input
                       type="text"
                       value={editName}

--- a/services/dashboard/src/app/globals.css
+++ b/services/dashboard/src/app/globals.css
@@ -4,12 +4,26 @@
 @tailwind components;
 @tailwind utilities;
 
+/* ─── Design tokens ──────────────────────────────────────────────────────── */
 :root {
   --foreground-rgb: 255, 255, 255;
   --background-start-rgb: 15, 23, 42;
   --background-end-rgb: 30, 41, 59;
+
+  /* Sidebar dimensions — referenced by Tailwind (w-sidebar-nav, w-sidebar-dmx)
+     and by components that need inline CSS (e.g. DMXChannelModal positioning) */
+  --sidebar-nav-width: 14rem;    /* 224px — left navigation sidebar (w-56) */
+  --sidebar-dmx-width: 295px;    /* DMX Lighting right sidebar             */
+
+  /* Z-index layers */
+  --z-nav-backdrop: 40;
+  --z-overlay: 50;
+
+  /* Mobile breakpoint reference (mirrors Tailwind's built-in `md`) */
+  --breakpoint-mobile: 768px;
 }
 
+/* ─── Global styles ──────────────────────────────────────────────────────── */
 body {
   color: rgb(var(--foreground-rgb));
   background: linear-gradient(
@@ -44,4 +58,32 @@ body {
 @keyframes fadeOut {
   from { opacity: 1; }
   to { opacity: 0; }
+}
+
+/* ─── Reusable component classes ─────────────────────────────────────────── */
+@layer components {
+  /**
+   * Full-screen modal backdrop with centered, safe-padded content.
+   * Use: <div class="modal-backdrop"> <div class="modal-panel max-w-lg"> … </div> </div>
+   */
+  .modal-backdrop {
+    @apply fixed inset-0 z-50 flex items-center justify-center bg-black/60 backdrop-blur-sm p-4;
+  }
+
+  /**
+   * Standard modal panel frame. Pair with a max-width utility (max-w-sm or
+   * max-w-lg) and any additional layout classes (flex flex-col, max-h-[90vh]).
+   */
+  .modal-panel {
+    @apply w-full bg-slate-900 border border-slate-700 rounded-xl shadow-2xl;
+  }
+
+  /**
+   * Mobile navigation drawer backdrop — visible only below the md breakpoint.
+   * Sits beneath the sidebar (z-40) so the drawer itself (z-50) renders above.
+   */
+  .nav-overlay-backdrop {
+    @apply fixed inset-0 bg-black/60 backdrop-blur-sm md:hidden;
+    z-index: var(--z-nav-backdrop);
+  }
 }

--- a/services/dashboard/src/app/page.tsx
+++ b/services/dashboard/src/app/page.tsx
@@ -1,5 +1,6 @@
 'use client'
 
+import { useState } from 'react'
 import Link from 'next/link'
 import { useActivityFeed, type ActivityItem, type ActivityCategory } from '@/hooks/useActivityFeed'
 import { SystemHealthBar } from '@/components/dashboard/SystemHealthBar'
@@ -7,30 +8,43 @@ import { ShowControlWidget } from '@/components/dashboard/ShowControlWidget'
 import { DeviceOverviewWidget } from '@/components/dashboard/DeviceOverviewWidget'
 import { EntitiesOverviewWidget } from '@/components/dashboard/EntitiesOverviewWidget'
 import { StreamsOverviewWidget } from '@/components/dashboard/StreamsOverviewWidget'
-import { Boxes, GitFork, Monitor, Zap, Radio } from '@/components/icons'
+import { Boxes, GitFork, Monitor, Zap, Radio, Activity, X } from '@/components/icons'
 
 export default function Home() {
   const { items: activityItems, isConnected } = useActivityFeed(50)
+  const [mobileView, setMobileView] = useState<'dashboard' | 'activity'>('dashboard')
 
   return (
     <div className="flex h-full">
-      {/* Main content */}
-      <div className="flex-1 overflow-auto p-6 space-y-4">
-        {/* Compact header */}
+
+      {/* ── Main dashboard content ─────────────────────────────────────── */}
+      <div className={`flex-1 overflow-auto p-4 md:p-6 space-y-4 ${mobileView === 'activity' ? 'hidden md:block' : ''}`}>
+
+        {/* Header */}
         <div className="flex items-center justify-between">
           <div>
             <h1 className="text-2xl font-bold">Dashboard</h1>
             <p className="text-sm text-slate-400 mt-0.5">Mission control</p>
           </div>
+
+          {/* Mobile-only: toggle to Live Activity view */}
+          <button
+            onClick={() => setMobileView('activity')}
+            className="md:hidden flex items-center gap-1.5 px-3 py-1.5 rounded-lg text-xs font-medium bg-slate-800 border border-slate-700 text-slate-400 hover:text-blue-400 hover:border-blue-500/30 transition-colors"
+          >
+            <span className={`w-1.5 h-1.5 rounded-full shrink-0 ${isConnected ? 'bg-green-500' : 'bg-red-500 animate-pulse'}`} />
+            <Activity className="w-3.5 h-3.5" />
+            Live Activity
+          </button>
         </div>
 
         {/* System Health Bar */}
         <SystemHealthBar />
 
-        {/* Show Control Widget (full-width, prominent) */}
+        {/* Show Control Widget */}
         <ShowControlWidget />
 
-        {/* Widget Grid (2-column) */}
+        {/* Widget Grid */}
         <div className="grid grid-cols-1 lg:grid-cols-2 gap-4">
           <DeviceOverviewWidget />
           <EntitiesOverviewWidget />
@@ -39,7 +53,7 @@ export default function Home() {
         {/* Streams Widget */}
         <StreamsOverviewWidget />
 
-        {/* Compact quick navigation */}
+        {/* Quick navigation */}
         <div className="flex flex-wrap gap-2 pt-2">
           {[
             { href: '/entities', label: 'Entities', icon: Boxes },
@@ -60,28 +74,45 @@ export default function Home() {
         </div>
       </div>
 
-      {/* Activity feed sidebar */}
-      <div className="w-80 border-l border-slate-800 bg-slate-900/50 overflow-auto p-4 shrink-0">
-        <div className="flex items-center justify-between mb-3">
+      {/* ── Live Activity feed ─────────────────────────────────────────── */}
+      {/* Desktop: fixed right sidebar. Mobile: full-width when toggled. */}
+      <div className={`
+        border-l border-slate-800 bg-slate-900/50 overflow-auto shrink-0
+        md:w-80 md:flex md:flex-col
+        ${mobileView === 'activity' ? 'flex flex-col flex-1' : 'hidden'}
+      `}>
+        <div className="flex items-center justify-between px-4 pt-4 pb-3 shrink-0">
           <h2 className="text-xs font-semibold text-slate-500 uppercase tracking-wider">
             Live Activity
           </h2>
-          <div className="flex items-center gap-1.5">
+          <div className="flex items-center gap-2">
             <span className={`w-1.5 h-1.5 rounded-full ${isConnected ? 'bg-green-500' : 'bg-red-500 animate-pulse'}`} />
             <span className="text-[10px] text-slate-600">{isConnected ? 'Live' : 'Offline'}</span>
+            {/* Mobile-only: close back to dashboard */}
+            <button
+              onClick={() => setMobileView('dashboard')}
+              className="md:hidden ml-1 text-slate-500 hover:text-slate-300 transition-colors p-0.5"
+              aria-label="Back to dashboard"
+            >
+              <X className="w-4 h-4" />
+            </button>
           </div>
         </div>
-        {activityItems.length === 0 && (
-          <p className="text-xs text-slate-600 text-center py-8">
-            {isConnected ? 'Waiting for events...' : 'Connecting to message bus...'}
-          </p>
-        )}
-        <div className="space-y-0.5">
-          {activityItems.map((item) => (
-            <ActivityRow key={item.id} item={item} />
-          ))}
+
+        <div className="flex-1 overflow-auto px-4 pb-4">
+          {activityItems.length === 0 && (
+            <p className="text-xs text-slate-600 text-center py-8">
+              {isConnected ? 'Waiting for events...' : 'Connecting to message bus...'}
+            </p>
+          )}
+          <div className="space-y-0.5">
+            {activityItems.map((item) => (
+              <ActivityRow key={item.id} item={item} />
+            ))}
+          </div>
         </div>
       </div>
+
     </div>
   )
 }

--- a/services/dashboard/src/components/AppShell.tsx
+++ b/services/dashboard/src/components/AppShell.tsx
@@ -3,6 +3,8 @@
 import { useState } from 'react'
 import { Sidebar } from './Sidebar'
 import { useOnboarding } from '@/hooks/useOnboarding'
+import { useSystemHealth } from '@/hooks/useSystemHealth'
+import { useWebSocket } from '@/hooks/useWebSocket'
 import { Menu } from '@/components/icons'
 
 /** Silently tracks page visits to auto-complete onboarding checklist steps */
@@ -11,8 +13,16 @@ function OnboardingTracker() {
   return null
 }
 
+const DOT_COLORS: Record<string, string> = {
+  healthy: 'bg-green-500',
+  unhealthy: 'bg-red-500',
+  checking: 'bg-slate-600 animate-pulse',
+}
+
 export function AppShell({ children }: { children: React.ReactNode }) {
   const [mobileSidebarOpen, setMobileSidebarOpen] = useState(false)
+  const { services } = useSystemHealth(30000)
+  const { isConnected: wsConnected } = useWebSocket()
 
   return (
     <div className="flex h-screen bg-slate-900 text-white overflow-hidden">
@@ -28,7 +38,7 @@ export function AppShell({ children }: { children: React.ReactNode }) {
       <OnboardingTracker />
 
       <div className="flex-1 flex flex-col overflow-hidden min-w-0">
-        {/* Mobile top bar — hamburger + logo */}
+        {/* Mobile top bar — hamburger + logo + system health dots */}
         <div className="flex items-center gap-3 px-4 py-3 border-b border-slate-800 bg-slate-900 md:hidden shrink-0">
           <button
             onClick={() => setMobileSidebarOpen(true)}
@@ -37,9 +47,28 @@ export function AppShell({ children }: { children: React.ReactNode }) {
           >
             <Menu className="w-5 h-5" />
           </button>
+
           <span className="text-base font-bold tracking-tight bg-gradient-to-r from-blue-400 to-purple-500 bg-clip-text text-transparent">
             Maestra
           </span>
+
+          {/* System health status dots */}
+          <div className="ml-auto flex items-center gap-2">
+            {services.map((service) => (
+              <span
+                key={service.name}
+                className={`w-2 h-2 rounded-full shrink-0 ${DOT_COLORS[service.status] ?? 'bg-slate-600'}`}
+                title={`${service.name}: ${service.status}`}
+                aria-label={`${service.name}: ${service.status}`}
+              />
+            ))}
+            {/* WebSocket dot */}
+            <span
+              className={`w-2 h-2 rounded-full shrink-0 ${wsConnected ? 'bg-green-500' : 'bg-red-500 animate-pulse'}`}
+              title={`WebSocket: ${wsConnected ? 'connected' : 'disconnected'}`}
+              aria-label={`WebSocket: ${wsConnected ? 'connected' : 'disconnected'}`}
+            />
+          </div>
         </div>
 
         <main className="flex-1 overflow-auto">

--- a/services/dashboard/src/components/AppShell.tsx
+++ b/services/dashboard/src/components/AppShell.tsx
@@ -5,7 +5,7 @@ import { Sidebar } from './Sidebar'
 import { useOnboarding } from '@/hooks/useOnboarding'
 import { useSystemHealth } from '@/hooks/useSystemHealth'
 import { useWebSocket } from '@/hooks/useWebSocket'
-import { Menu } from '@/components/icons'
+import { Menu, Server, MessageSquare, Database, Cloud, Wifi } from '@/components/icons'
 
 /** Silently tracks page visits to auto-complete onboarding checklist steps */
 function OnboardingTracker() {
@@ -17,6 +17,13 @@ const DOT_COLORS: Record<string, string> = {
   healthy: 'bg-green-500',
   unhealthy: 'bg-red-500',
   checking: 'bg-slate-600 animate-pulse',
+}
+
+const SERVICE_ICONS: Record<string, React.ComponentType<{ className?: string }>> = {
+  'Fleet Manager': Server,
+  'Message Bus': MessageSquare,
+  'Database': Database,
+  'Cloud Gateway': Cloud,
 }
 
 export function AppShell({ children }: { children: React.ReactNode }) {
@@ -53,21 +60,30 @@ export function AppShell({ children }: { children: React.ReactNode }) {
           </span>
 
           {/* System health status dots */}
-          <div className="ml-auto flex items-center gap-2">
-            {services.map((service) => (
-              <span
-                key={service.name}
-                className={`w-2 h-2 rounded-full shrink-0 ${DOT_COLORS[service.status] ?? 'bg-slate-600'}`}
-                title={`${service.name}: ${service.status}`}
-                aria-label={`${service.name}: ${service.status}`}
-              />
-            ))}
-            {/* WebSocket dot */}
-            <span
-              className={`w-2 h-2 rounded-full shrink-0 ${wsConnected ? 'bg-green-500' : 'bg-red-500 animate-pulse'}`}
+          <div className="ml-auto flex items-center gap-2.5">
+            {services.map((service) => {
+              const Icon = SERVICE_ICONS[service.name]
+              return (
+                <div
+                  key={service.name}
+                  className="flex items-center gap-1"
+                  title={`${service.name}: ${service.status}`}
+                  aria-label={`${service.name}: ${service.status}`}
+                >
+                  {Icon && <Icon className="w-3 h-3 text-slate-500" />}
+                  <span className={`w-1.5 h-1.5 rounded-full shrink-0 ${DOT_COLORS[service.status] ?? 'bg-slate-600'}`} />
+                </div>
+              )
+            })}
+            {/* WebSocket indicator */}
+            <div
+              className="flex items-center gap-1"
               title={`WebSocket: ${wsConnected ? 'connected' : 'disconnected'}`}
               aria-label={`WebSocket: ${wsConnected ? 'connected' : 'disconnected'}`}
-            />
+            >
+              <Wifi className="w-3 h-3 text-slate-500" />
+              <span className={`w-1.5 h-1.5 rounded-full shrink-0 ${wsConnected ? 'bg-green-500' : 'bg-red-500 animate-pulse'}`} />
+            </div>
           </div>
         </div>
 

--- a/services/dashboard/src/components/AppShell.tsx
+++ b/services/dashboard/src/components/AppShell.tsx
@@ -19,7 +19,7 @@ export function AppShell({ children }: { children: React.ReactNode }) {
       {/* Mobile backdrop */}
       {mobileSidebarOpen && (
         <div
-          className="fixed inset-0 z-40 bg-black/60 backdrop-blur-sm md:hidden"
+          className="nav-overlay-backdrop"
           onClick={() => setMobileSidebarOpen(false)}
         />
       )}

--- a/services/dashboard/src/components/AppShell.tsx
+++ b/services/dashboard/src/components/AppShell.tsx
@@ -1,7 +1,9 @@
 'use client'
 
+import { useState } from 'react'
 import { Sidebar } from './Sidebar'
 import { useOnboarding } from '@/hooks/useOnboarding'
+import { Menu } from '@/components/icons'
 
 /** Silently tracks page visits to auto-complete onboarding checklist steps */
 function OnboardingTracker() {
@@ -10,13 +12,40 @@ function OnboardingTracker() {
 }
 
 export function AppShell({ children }: { children: React.ReactNode }) {
+  const [mobileSidebarOpen, setMobileSidebarOpen] = useState(false)
+
   return (
     <div className="flex h-screen bg-slate-900 text-white overflow-hidden">
-      <Sidebar />
+      {/* Mobile backdrop */}
+      {mobileSidebarOpen && (
+        <div
+          className="fixed inset-0 z-40 bg-black/60 backdrop-blur-sm md:hidden"
+          onClick={() => setMobileSidebarOpen(false)}
+        />
+      )}
+
+      <Sidebar isOpen={mobileSidebarOpen} onClose={() => setMobileSidebarOpen(false)} />
       <OnboardingTracker />
-      <main className="flex-1 overflow-auto">
-        {children}
-      </main>
+
+      <div className="flex-1 flex flex-col overflow-hidden min-w-0">
+        {/* Mobile top bar — hamburger + logo */}
+        <div className="flex items-center gap-3 px-4 py-3 border-b border-slate-800 bg-slate-900 md:hidden shrink-0">
+          <button
+            onClick={() => setMobileSidebarOpen(true)}
+            className="text-slate-400 hover:text-white transition-colors p-0.5"
+            aria-label="Open navigation"
+          >
+            <Menu className="w-5 h-5" />
+          </button>
+          <span className="text-base font-bold tracking-tight bg-gradient-to-r from-blue-400 to-purple-500 bg-clip-text text-transparent">
+            Maestra
+          </span>
+        </div>
+
+        <main className="flex-1 overflow-auto">
+          {children}
+        </main>
+      </div>
     </div>
   )
 }

--- a/services/dashboard/src/components/Sidebar.tsx
+++ b/services/dashboard/src/components/Sidebar.tsx
@@ -210,7 +210,7 @@ export function Sidebar({ isOpen = false, onClose }: SidebarProps) {
   return (
     <aside
       className={`
-        fixed inset-y-0 left-0 z-50 w-56
+        fixed inset-y-0 left-0 z-50 w-sidebar-nav
         transform transition-transform duration-300 ease-in-out
         md:relative md:translate-x-0 md:z-auto md:transition-none
         ${isOpen ? 'translate-x-0' : '-translate-x-full'}

--- a/services/dashboard/src/components/Sidebar.tsx
+++ b/services/dashboard/src/components/Sidebar.tsx
@@ -18,7 +18,8 @@ import {
   Settings,
   Cloud,
   Zap,
-  Play
+  Play,
+  X,
 } from '@/components/icons'
 import { getServiceLinks } from '@/lib/hosts'
 import { useSystemHealth } from '@/hooks/useSystemHealth'
@@ -60,7 +61,12 @@ function getServiceLinkItems(): ServiceLink[] {
   ]
 }
 
-export function Sidebar() {
+interface SidebarProps {
+  isOpen?: boolean
+  onClose?: () => void
+}
+
+export function Sidebar({ isOpen = false, onClose }: SidebarProps) {
   const pathname = usePathname()
   const { services } = useSystemHealth(30000)
   const [cloudStatus, setCloudStatus] = useState<'none' | 'connected' | 'disconnected' | 'connecting' | 'error'>('none')
@@ -87,20 +93,30 @@ export function Sidebar() {
     return () => clearInterval(timer)
   }, [])
 
-  return (
-    <aside className="w-56 shrink-0 bg-slate-900 border-r border-slate-800 flex flex-col">
+  const sidebarContent = (
+    <>
       {/* Logo */}
-      <div className="px-5 py-4 border-b border-slate-800">
-        <Link href="/" className="flex items-center gap-2">
+      <div className="px-5 py-4 border-b border-slate-800 flex items-center justify-between">
+        <Link href="/" onClick={onClose} className="flex items-center gap-2">
           <span className="text-xl text-purple-400">{'\u2726'}</span>
           <span className="text-lg font-bold tracking-tight bg-gradient-to-r from-blue-400 to-purple-500 bg-clip-text text-transparent">
             Maestra
           </span>
         </Link>
+        {/* Close button — mobile only */}
+        {onClose && (
+          <button
+            onClick={onClose}
+            className="md:hidden text-slate-500 hover:text-white transition-colors p-0.5"
+            aria-label="Close navigation"
+          >
+            <X className="w-4 h-4" />
+          </button>
+        )}
       </div>
 
       {/* Navigation */}
-      <nav className="flex-1 px-3 py-4 space-y-1">
+      <nav className="flex-1 px-3 py-4 space-y-1 overflow-y-auto">
         {NAV_ITEMS.map((item) => {
           const isActive = item.href === '/'
             ? pathname === '/'
@@ -110,6 +126,7 @@ export function Sidebar() {
             <Link
               key={item.href}
               href={item.href}
+              onClick={onClose}
               className={`flex items-center gap-3 px-3 py-2 rounded-lg text-sm font-medium transition-colors ${
                 isActive
                   ? 'bg-slate-800 text-white'
@@ -187,6 +204,20 @@ export function Sidebar() {
           )
         })}
       </div>
+    </>
+  )
+
+  return (
+    <aside
+      className={`
+        fixed inset-y-0 left-0 z-50 w-56
+        transform transition-transform duration-300 ease-in-out
+        md:relative md:translate-x-0 md:z-auto md:transition-none
+        ${isOpen ? 'translate-x-0' : '-translate-x-full'}
+        bg-slate-900 border-r border-slate-800 flex flex-col shrink-0
+      `}
+    >
+      {sidebarContent}
     </aside>
   )
 }

--- a/services/dashboard/src/components/dmx/AddFixtureModal.tsx
+++ b/services/dashboard/src/components/dmx/AddFixtureModal.tsx
@@ -386,8 +386,8 @@ export function AddFixtureModal({ nodes, fixtures, groups = [], fixture, copyOf,
   }
 
   return (
-    <div className="fixed inset-0 z-50 flex items-center justify-center bg-black/60 backdrop-blur-sm p-4">
-      <div className="w-full max-w-lg bg-slate-900 border border-slate-700 rounded-xl shadow-2xl flex flex-col max-h-[90vh]">
+    <div className="modal-backdrop">
+      <div className="modal-panel max-w-lg flex flex-col max-h-[90vh]">
         {/* Header */}
         <div className="flex items-center justify-between px-5 py-4 border-b border-slate-800 shrink-0">
           <div>

--- a/services/dashboard/src/components/dmx/AddFixtureModal.tsx
+++ b/services/dashboard/src/components/dmx/AddFixtureModal.tsx
@@ -64,7 +64,6 @@ export function AddFixtureModal({ nodes, fixtures, groups = [], fixture, copyOf,
     isEditing ? (fixture?.entity_slug ?? '') : slugify(initialName ?? source?.name ?? '')
   )
   const [slugManuallyEdited, setSlugManuallyEdited] = useState(isEditing)
-  const [label, setLabel] = useState(source?.label ?? '')
   const [fixtureMode, setFixtureMode] = useState(source?.fixture_mode ?? '')
   const initialNodeId = source?.node_id ?? nodes[0]?.id ?? ''
   const initialUniverse = source?.universe ?? 1
@@ -110,6 +109,9 @@ export function AddFixtureModal({ nodes, fixtures, groups = [], fixture, copyOf,
 
   // Track all fixture names for auto-numbering
   const [allFixtureNames, setAllFixtureNames] = useState<string[]>([])
+  useEffect(() => {
+    setAllFixtureNames(fixtures.map((f) => f.name))
+  }, [fixtures])
 
   const selectedNode = nodes.find((n) => n.id === nodeId)
   const selectedEntity = entities.find((e) => e.id === entityId) ?? null
@@ -364,7 +366,6 @@ export function AddFixtureModal({ nodes, fixtures, groups = [], fixture, copyOf,
 
       await onSubmit({
         name: name.trim(),
-        label: label.trim() || undefined,
         fixture_mode: fixtureMode.trim() || undefined,
         node_id: nodeId,
         universe,
@@ -378,6 +379,14 @@ export function AddFixtureModal({ nodes, fixtures, groups = [], fixture, copyOf,
         position_x: (isCopying ? (copyOf!.position_x + 40) : fixture?.position_x) ?? defaultPosition?.x ?? 200,
         position_y: (isCopying ? (copyOf!.position_y + 40) : fixture?.position_y) ?? defaultPosition?.y ?? 200,
       })
+      // In edit mode, keep the linked entity's display name in sync with the fixture name
+      if (isEditing && resolvedEntityId) {
+        try {
+          await entitiesApi.update(resolvedEntityId, { name: name.trim() })
+        } catch {
+          // Non-fatal: display name sync failure doesn't block the save
+        }
+      }
       onClose()
     } catch (e) {
       setError(e instanceof Error ? e.message : isEditing ? 'Failed to update fixture' : 'Failed to create fixture')
@@ -609,17 +618,8 @@ export function AddFixtureModal({ nodes, fixtures, groups = [], fixture, copyOf,
                   </select>
                 </div>
               )}
-              <div>
-                <label className="block text-xs text-slate-400 mb-1">Short Label</label>
-                <input
-                  value={label}
-                  onChange={(e) => setLabel(e.target.value)}
-                  placeholder="e.g. FWL"
-                  className="w-full bg-slate-800 border border-slate-700 rounded-lg px-3 py-2 text-sm text-white placeholder-slate-600 focus:outline-none focus:border-blue-500"
-                />
-              </div>
               {isEditing && editOFLFixture && editOFLFixture.modes.length > 0 && (
-                <div>
+                <div className="col-span-2">
                   <label className="block text-xs text-slate-400 mb-1 flex items-center gap-2">
                     Fixture Mode
                     <span className="text-[9px] font-medium px-1.5 py-0.5 rounded bg-emerald-900/40 border border-emerald-800/50 text-emerald-400 normal-case tracking-normal">

--- a/services/dashboard/src/components/dmx/AddFixtureModal.tsx
+++ b/services/dashboard/src/components/dmx/AddFixtureModal.tsx
@@ -386,7 +386,7 @@ export function AddFixtureModal({ nodes, fixtures, groups = [], fixture, copyOf,
   }
 
   return (
-    <div className="fixed inset-0 z-50 flex items-center justify-center bg-black/60 backdrop-blur-sm">
+    <div className="fixed inset-0 z-50 flex items-center justify-center bg-black/60 backdrop-blur-sm p-4">
       <div className="w-full max-w-lg bg-slate-900 border border-slate-700 rounded-xl shadow-2xl flex flex-col max-h-[90vh]">
         {/* Header */}
         <div className="flex items-center justify-between px-5 py-4 border-b border-slate-800 shrink-0">

--- a/services/dashboard/src/components/dmx/DMXChannelModal.tsx
+++ b/services/dashboard/src/components/dmx/DMXChannelModal.tsx
@@ -42,6 +42,13 @@ export function DMXChannelModal({ fixtures, onClose, onDMXChannelChange }: DMXCh
 
   const [values, setValues] = useState<Record<string, number>>({})
   const [loading, setLoading] = useState(true)
+  const [isMobile, setIsMobile] = useState(false)
+  useEffect(() => {
+    const check = () => setIsMobile(window.innerWidth < 768)
+    check()
+    window.addEventListener('resize', check)
+    return () => window.removeEventListener('resize', check)
+  }, [])
   const debounceRefs = useRef<Record<string, ReturnType<typeof setTimeout>>>({})
 
   // Snapshot of state at the time the panel opened — used by Cancel & Reset
@@ -178,23 +185,30 @@ export function DMXChannelModal({ fixtures, onClose, onDMXChannelChange }: DMXCh
   }, [handleCancelAndReset])
 
   return (
-    <div className="fixed inset-0 z-50 flex items-start pointer-events-none" style={{ paddingTop: '3rem' }}>
-      {/* Darkened/blurred backdrop covering canvas area only */}
+    <div
+      className="fixed inset-0 z-50 flex items-center pointer-events-none"
+      style={isMobile ? { alignItems: 'flex-end' } : { alignItems: 'flex-start', paddingTop: '3rem' }}
+    >
+      {/* Backdrop — full screen on mobile, canvas-area only on desktop */}
       <div
         className="absolute inset-0 pointer-events-auto bg-black/60 backdrop-blur-sm"
-        style={{ left: '14rem', right: '16rem' }}
+        style={isMobile ? {} : { left: '14rem', right: '16rem' }}
         onClick={onClose}
       />
 
-      {/* Modal — inset within left nav (w-56=14rem) and right DMX sidebar (w-64=16rem) */}
+      {/* Modal — bottom sheet on mobile, canvas-inset on desktop */}
       <div
-        className="relative pointer-events-auto flex flex-col bg-slate-900 border border-slate-700 rounded-xl shadow-2xl"
-        style={{
-          marginLeft: 'calc(14rem + 16px)',
-          marginRight: 'calc(16rem + 16px)',
-          maxHeight: '70vh',
-          flex: 1,
-        }}
+        className="relative pointer-events-auto flex flex-col bg-slate-900 border border-slate-700 shadow-2xl"
+        style={isMobile
+          ? { width: '100%', maxHeight: '85vh', borderRadius: '1rem 1rem 0 0', borderBottom: 'none' }
+          : {
+              marginLeft: 'calc(14rem + 16px)',
+              marginRight: 'calc(16rem + 16px)',
+              maxHeight: '70vh',
+              flex: 1,
+              borderRadius: '0.75rem',
+            }
+        }
         onClick={(e) => e.stopPropagation()}
       >
         {/* Header */}

--- a/services/dashboard/src/components/dmx/DMXChannelModal.tsx
+++ b/services/dashboard/src/components/dmx/DMXChannelModal.tsx
@@ -192,7 +192,7 @@ export function DMXChannelModal({ fixtures, onClose, onDMXChannelChange }: DMXCh
       {/* Backdrop — full screen on mobile, canvas-area only on desktop */}
       <div
         className="absolute inset-0 pointer-events-auto bg-black/60 backdrop-blur-sm"
-        style={isMobile ? {} : { left: '14rem', right: '16rem' }}
+        style={isMobile ? {} : { left: 'var(--sidebar-nav-width)', right: 'var(--sidebar-dmx-width)' }}
         onClick={onClose}
       />
 
@@ -202,8 +202,8 @@ export function DMXChannelModal({ fixtures, onClose, onDMXChannelChange }: DMXCh
         style={isMobile
           ? { width: '100%', maxHeight: '85vh', borderRadius: '1rem 1rem 0 0', borderBottom: 'none' }
           : {
-              marginLeft: 'calc(14rem + 16px)',
-              marginRight: 'calc(16rem + 16px)',
+              marginLeft: 'calc(var(--sidebar-nav-width) + 16px)',
+              marginRight: 'calc(var(--sidebar-dmx-width) + 16px)',
               maxHeight: '70vh',
               flex: 1,
               borderRadius: '0.75rem',

--- a/services/dashboard/src/components/dmx/DMXChannelModal.tsx
+++ b/services/dashboard/src/components/dmx/DMXChannelModal.tsx
@@ -2,7 +2,7 @@
 
 import { useState, useEffect, useCallback, useRef } from 'react'
 import { DMXFixture, ChannelMapping } from '@/lib/types'
-import { X, SlidersHorizontal, RotateCcw, ChevronUp, ChevronDown, Undo2 } from '@/components/icons'
+import { X, SlidersHorizontal, RotateCcw, ChevronUp, ChevronDown, Undo2, Move, Crosshair } from '@/components/icons'
 import { entitiesApi } from '@/lib/api'
 import { useWebSocket } from '@/hooks/useWebSocket'
 
@@ -35,20 +35,180 @@ interface DMXChannelModalProps {
   onDMXChannelChange?: () => void
 }
 
+// ── Pan/Tilt Joystick ─────────────────────────────────────────────────────────
+
+interface PanTiltJoystickProps {
+  panValue: number
+  tiltValue: number
+  padSize: number
+  onChange: (pan: number, tilt: number) => void
+}
+
+function PanTiltJoystick({ panValue, tiltValue, padSize, onChange }: PanTiltJoystickProps) {
+  const padRef = useRef<HTMLDivElement>(null)
+  const isDragging = useRef(false)
+  // Keep a stable ref to onChange so event listeners don't go stale
+  const onChangeRef = useRef(onChange)
+  useEffect(() => { onChangeRef.current = onChange }, [onChange])
+
+  const getValues = useCallback((clientX: number, clientY: number) => {
+    if (!padRef.current) return { pan: 0, tilt: 0 }
+    const rect = padRef.current.getBoundingClientRect()
+    const pan = Math.round(Math.max(0, Math.min(1, (clientX - rect.left) / rect.width)) * 255)
+    const tilt = Math.round(Math.max(0, Math.min(1, (clientY - rect.top) / rect.height)) * 255)
+    return { pan, tilt }
+  }, [])
+
+  // Mouse: track drag globally so fast moves don't escape the pad
+  useEffect(() => {
+    const onMove = (e: MouseEvent) => {
+      if (!isDragging.current) return
+      const { pan, tilt } = getValues(e.clientX, e.clientY)
+      onChangeRef.current(pan, tilt)
+    }
+    const onUp = () => { isDragging.current = false }
+    window.addEventListener('mousemove', onMove)
+    window.addEventListener('mouseup', onUp)
+    return () => {
+      window.removeEventListener('mousemove', onMove)
+      window.removeEventListener('mouseup', onUp)
+    }
+  }, [getValues])
+
+  const handleMouseDown = useCallback((e: React.MouseEvent) => {
+    isDragging.current = true
+    const { pan, tilt } = getValues(e.clientX, e.clientY)
+    onChangeRef.current(pan, tilt)
+  }, [getValues])
+
+  // Touch: add imperatively with { passive: false } so preventDefault works
+  useEffect(() => {
+    const el = padRef.current
+    if (!el) return
+    const onTouchStart = (e: TouchEvent) => {
+      e.preventDefault()
+      const t = e.touches[0]
+      const { pan, tilt } = getValues(t.clientX, t.clientY)
+      onChangeRef.current(pan, tilt)
+    }
+    const onTouchMove = (e: TouchEvent) => {
+      e.preventDefault()
+      const t = e.touches[0]
+      const { pan, tilt } = getValues(t.clientX, t.clientY)
+      onChangeRef.current(pan, tilt)
+    }
+    el.addEventListener('touchstart', onTouchStart, { passive: false })
+    el.addEventListener('touchmove', onTouchMove, { passive: false })
+    return () => {
+      el.removeEventListener('touchstart', onTouchStart)
+      el.removeEventListener('touchmove', onTouchMove)
+    }
+  }, [getValues])
+
+  const dotLeft = `${(panValue / 255) * 100}%`
+  const dotTop = `${(tiltValue / 255) * 100}%`
+
+  return (
+    <div className="flex flex-col items-center gap-4">
+      {/* Pad */}
+      <div
+        ref={padRef}
+        onMouseDown={handleMouseDown}
+        className="relative rounded-xl border border-slate-700 bg-slate-800/80 cursor-crosshair select-none touch-none overflow-hidden"
+        style={{ width: padSize, height: padSize }}
+      >
+        {/* Grid — thirds */}
+        {[1, 2].map((n) => (
+          <div key={`h${n}`}
+            className="absolute left-0 right-0 border-t border-slate-700/40 pointer-events-none"
+            style={{ top: `${(n / 3) * 100}%` }}
+          />
+        ))}
+        {[1, 2].map((n) => (
+          <div key={`v${n}`}
+            className="absolute top-0 bottom-0 border-l border-slate-700/40 pointer-events-none"
+            style={{ left: `${(n / 3) * 100}%` }}
+          />
+        ))}
+
+        {/* Center crosshair */}
+        <div className="absolute top-1/2 left-0 right-0 border-t border-slate-600/60 pointer-events-none" />
+        <div className="absolute left-1/2 top-0 bottom-0 border-l border-slate-600/60 pointer-events-none" />
+
+        {/* Position dot with ring — container sized to ring, flex-centers the dot */}
+        <div
+          className="absolute pointer-events-none flex items-center justify-center rounded-full bg-blue-500/20"
+          style={{ width: 32, height: 32, left: dotLeft, top: dotTop, transform: 'translate(-50%, -50%)' }}
+        >
+          <div className="w-5 h-5 rounded-full bg-blue-500 border-2 border-white shadow-lg shadow-blue-500/40" />
+        </div>
+
+        {/* Axis labels */}
+        <div className="absolute bottom-1.5 left-0 right-0 flex justify-between px-2 pointer-events-none">
+          <span className="text-[9px] text-slate-600 font-mono">PAN 0</span>
+          <span className="text-[9px] text-slate-500 font-mono uppercase tracking-widest">← pan →</span>
+          <span className="text-[9px] text-slate-600 font-mono">255</span>
+        </div>
+        <div className="absolute left-1.5 top-0 bottom-0 flex flex-col justify-between py-5 pointer-events-none">
+          <span className="text-[9px] text-slate-600 font-mono" style={{ writingMode: 'vertical-rl', transform: 'rotate(180deg)' }}>0</span>
+          <span className="text-[9px] text-slate-500 font-mono" style={{ writingMode: 'vertical-rl', transform: 'rotate(180deg)' }}>TILT</span>
+          <span className="text-[9px] text-slate-600 font-mono" style={{ writingMode: 'vertical-rl', transform: 'rotate(180deg)' }}>255</span>
+        </div>
+      </div>
+
+      {/* Value readout + center button */}
+      <div className="flex items-center gap-6">
+        <div className="text-center min-w-[48px]">
+          <div className="text-[10px] text-slate-500 uppercase tracking-wider">Pan</div>
+          <div className="text-sm text-blue-400 font-mono font-semibold tabular-nums">{panValue}</div>
+        </div>
+        <button
+          onClick={() => onChangeRef.current(127, 127)}
+          className="flex items-center gap-1.5 px-3 py-1.5 rounded-lg text-xs text-slate-400 bg-slate-800 hover:bg-slate-700 hover:text-white border border-slate-700 transition-colors"
+          title="Center (127, 127)"
+        >
+          <Crosshair className="w-3.5 h-3.5" />
+          Center
+        </button>
+        <div className="text-center min-w-[48px]">
+          <div className="text-[10px] text-slate-500 uppercase tracking-wider">Tilt</div>
+          <div className="text-sm text-blue-400 font-mono font-semibold tabular-nums">{tiltValue}</div>
+        </div>
+      </div>
+    </div>
+  )
+}
+
+// ── Main modal ────────────────────────────────────────────────────────────────
+
 export function DMXChannelModal({ fixtures, onClose, onDMXChannelChange }: DMXChannelModalProps) {
   const primary = fixtures[0]
   const channelMap = primary?.channel_map ?? {}
   const channels = Object.entries(channelMap).sort(([, a], [, b]) => a.offset - b.offset)
 
+  // Detect coarse pan/tilt channels (exclude fine channels)
+  const panKey = channels.find(([k, ch]) => {
+    const lbl = ((ch as ChannelMapping).label ?? k).toLowerCase()
+    return (k === 'pan' || lbl === 'pan') && !k.includes('fine')
+  })?.[0]
+  const tiltKey = channels.find(([k, ch]) => {
+    const lbl = ((ch as ChannelMapping).label ?? k).toLowerCase()
+    return (k === 'tilt' || lbl === 'tilt') && !k.includes('fine')
+  })?.[0]
+  const hasPanTilt = !!(panKey && tiltKey)
+
   const [values, setValues] = useState<Record<string, number>>({})
   const [loading, setLoading] = useState(true)
   const [isMobile, setIsMobile] = useState(false)
+  const [viewMode, setViewMode] = useState<'sliders' | 'joystick'>('sliders')
+
   useEffect(() => {
     const check = () => setIsMobile(window.innerWidth < 768)
     check()
     window.addEventListener('resize', check)
     return () => window.removeEventListener('resize', check)
   }, [])
+
   const debounceRefs = useRef<Record<string, ReturnType<typeof setTimeout>>>({})
 
   // Snapshot of state at the time the panel opened — used by Cancel & Reset
@@ -102,7 +262,7 @@ export function DMXChannelModal({ fixtures, onClose, onDMXChannelChange }: DMXCh
     if (!lastMessage) return
     const event = (lastMessage.data ?? {}) as Record<string, unknown>
     if (event.type !== 'state_changed') return
-    // Ignore updates we generated ourselves (slider moves)
+    // Ignore updates we generated ourselves (slider/joystick moves)
     if (event.source === 'dashboard-dmx' || event.source === 'dmx_panel') return
     if (!event.entity_id || !fixtureEntityIds.has(event.entity_id as string)) return
     const incoming = (event.current_state ?? {}) as Record<string, unknown>
@@ -152,6 +312,11 @@ export function DMXChannelModal({ fixtures, onClose, onDMXChannelChange }: DMXCh
     }, 50)
   }, [fixtures, onDMXChannelChange])
 
+  const handleJoystickChange = useCallback((pan: number, tilt: number) => {
+    if (panKey) handleChange(panKey, pan)
+    if (tiltKey) handleChange(tiltKey, tilt)
+  }, [panKey, tiltKey, handleChange])
+
   const handleCancelAndReset = useCallback(() => {
     const snapshot = initialSnapshot.current
     if (!snapshot) { onClose(); return }
@@ -183,6 +348,8 @@ export function DMXChannelModal({ fixtures, onClose, onDMXChannelChange }: DMXCh
     document.addEventListener('keydown', handler)
     return () => document.removeEventListener('keydown', handler)
   }, [handleCancelAndReset])
+
+  const padSize = isMobile ? Math.min(280, (typeof window !== 'undefined' ? window.innerWidth : 375) - 64) : 240
 
   return (
     <div
@@ -230,13 +397,40 @@ export function DMXChannelModal({ fixtures, onClose, onDMXChannelChange }: DMXCh
             </div>
           </div>
           <div className="flex items-center gap-2">
+            {/* Pan/Tilt toggle — only shown when fixture has both channels */}
+            {hasPanTilt && !loading && (
+              <div className="flex items-center rounded-lg bg-slate-800 border border-slate-700 p-0.5">
+                <button
+                  onClick={() => setViewMode('sliders')}
+                  className={`flex items-center gap-1.5 px-2.5 py-1 rounded-md text-xs transition-colors ${
+                    viewMode === 'sliders'
+                      ? 'bg-blue-600 text-white'
+                      : 'text-slate-400 hover:text-slate-200'
+                  }`}
+                >
+                  <SlidersHorizontal className="w-3 h-3" />
+                  <span className="hidden sm:inline">Channels</span>
+                </button>
+                <button
+                  onClick={() => setViewMode('joystick')}
+                  className={`flex items-center gap-1.5 px-2.5 py-1 rounded-md text-xs transition-colors ${
+                    viewMode === 'joystick'
+                      ? 'bg-blue-600 text-white'
+                      : 'text-slate-400 hover:text-slate-200'
+                  }`}
+                >
+                  <Move className="w-3 h-3" />
+                  <span className="hidden sm:inline">Pan·Tilt</span>
+                </button>
+              </div>
+            )}
             <button
               onClick={handleZeroAll}
               title="Zero all channels"
               className="flex items-center gap-1.5 px-2.5 py-1 rounded-md text-xs text-slate-400 bg-slate-800 hover:bg-slate-700 hover:text-white transition-colors"
             >
               <RotateCcw className="w-3 h-3" />
-              Zero All
+              <span className="hidden sm:inline">Zero All</span>
             </button>
             <button
               onClick={handleCancelAndReset}
@@ -244,7 +438,7 @@ export function DMXChannelModal({ fixtures, onClose, onDMXChannelChange }: DMXCh
               className="flex items-center gap-1.5 px-2.5 py-1 rounded-md text-xs text-slate-400 bg-slate-800 hover:bg-red-900/60 hover:text-red-300 hover:border-red-700/50 border border-transparent transition-colors"
             >
               <Undo2 className="w-3 h-3" />
-              Cancel & Reset
+              <span className="hidden sm:inline">Cancel & Reset</span>
             </button>
             <button onClick={onClose} className="text-slate-500 hover:text-slate-300 transition-colors">
               <X className="w-4 h-4" />
@@ -252,8 +446,8 @@ export function DMXChannelModal({ fixtures, onClose, onDMXChannelChange }: DMXCh
           </div>
         </div>
 
-        {/* Sliders */}
-        <div className="flex-1 overflow-x-auto overflow-y-hidden px-5 py-4">
+        {/* Body */}
+        <div className={`flex-1 overflow-auto px-5 py-4 ${viewMode === 'joystick' ? 'flex items-center justify-center' : 'overflow-x-auto overflow-y-hidden'}`}>
           {loading ? (
             <div className="h-full flex items-center justify-center">
               <span className="text-sm text-slate-600">Loading…</span>
@@ -264,6 +458,13 @@ export function DMXChannelModal({ fixtures, onClose, onDMXChannelChange }: DMXCh
                 No channel map — select a fixture mode when adding the fixture
               </span>
             </div>
+          ) : viewMode === 'joystick' && hasPanTilt && panKey && tiltKey ? (
+            <PanTiltJoystick
+              panValue={values[panKey] ?? 127}
+              tiltValue={values[tiltKey] ?? 127}
+              padSize={padSize}
+              onChange={handleJoystickChange}
+            />
           ) : (
             <div className="flex gap-5 h-full items-start min-w-max">
               {channels.map(([key, ch]) => {

--- a/services/dashboard/src/components/dmx/DMXSidebar.tsx
+++ b/services/dashboard/src/components/dmx/DMXSidebar.tsx
@@ -88,6 +88,7 @@ interface DMXSidebarProps {
   openSequencesSignal?: number
   availableCues: DMXCue[]
   onCreateSequence: (groupId?: string) => void
+  onAdjustFixture?: (fixture: DMXFixture) => void
 }
 
 type ActiveSection = 'nodes' | 'fixtures' | 'groups' | 'cues' | 'sequences'
@@ -98,7 +99,7 @@ export function DMXSidebar({
   cues, activeCueId, editingCueId, cueFadeProgress, onRecallCue, onEnterEditCue, onExitEditCue, onRenameCue, onDeleteCue, onReorderCues, onOpenCues, onSaveCue, onUpdateCue, updateCueLoading,
   sequences, getStatusForSeq, activeGroupIds, onPlaySequence, onPauseSequence, onStopSequence, onRenameSequence, onDeleteSequence,
   onReorderSequences, onAddCueToSequence, onReorderSequenceCues, onUpdatePlacement, onRemoveCueFromSequence,
-  onOpenSequences, openSequencesSignal, availableCues, onToggleLoop, onFadeOut, onBlackout, onCreateSequence,
+  onOpenSequences, openSequencesSignal, availableCues, onToggleLoop, onFadeOut, onBlackout, onCreateSequence, onAdjustFixture,
 }: DMXSidebarProps) {
   const SESSION_KEY = 'dmx-sidebar-section'
   const [active, setActive] = useState<ActiveSection>(() => {
@@ -263,7 +264,7 @@ export function DMXSidebar({
 
   return (
     <>
-    <aside className="w-[295px] shrink-0 bg-slate-900 border-l border-slate-800 flex flex-col overflow-hidden">
+    <aside className="w-full md:w-[295px] md:shrink-0 bg-slate-900 md:border-l border-slate-800 flex flex-col overflow-hidden">
 
       {/* ── Art-Net Nodes section ───────────────────────────────────── */}
       <div className="flex flex-col shrink-0" style={{ transition: 'flex 350ms cubic-bezier(0.4,0,0.2,1)' }}>
@@ -511,20 +512,29 @@ export function DMXSidebar({
                                 <div className="flex items-center gap-1">
                                   <GripVertical className="w-3 h-3 text-slate-700 group-hover:text-slate-500 transition-colors shrink-0 cursor-grab active:cursor-grabbing" />
                                   <div className="text-xs font-medium text-slate-200 truncate flex-1">{fixture.label || fixture.name}</div>
-                                  <div className="flex items-center gap-1 shrink-0 opacity-0 group-hover:opacity-100 transition-opacity">
+                                  {/* Action buttons: always visible on mobile, hover-only on desktop */}
+                                  <div className="flex items-center gap-1 shrink-0 md:opacity-0 md:group-hover:opacity-100 transition-opacity">
                                     <button
-                                      onClick={(e) => { e.stopPropagation(); onAdjustDMX(); onSelect(fixture.id) }}
+                                      onClick={(e) => {
+                                        e.stopPropagation()
+                                        if (onAdjustFixture) {
+                                          onAdjustFixture(fixture)
+                                        } else {
+                                          onSelect(fixture.id)
+                                          onAdjustDMX()
+                                        }
+                                      }}
                                       title="Adjust DMX channels"
-                                      className="text-slate-600 hover:text-blue-400 transition-colors"
+                                      className="text-slate-600 hover:text-blue-400 transition-colors p-0.5"
                                     >
-                                      <SlidersHorizontal className="w-3 h-3" />
+                                      <SlidersHorizontal className="w-3.5 h-3.5" />
                                     </button>
                                     <button
                                       onClick={(e) => { e.stopPropagation(); onEdit(fixture) }}
                                       title="Edit fixture"
-                                      className="text-slate-600 hover:text-slate-300 transition-colors"
+                                      className="text-slate-600 hover:text-slate-300 transition-colors p-0.5"
                                     >
-                                      <Pencil className="w-3 h-3" />
+                                      <Pencil className="w-3.5 h-3.5" />
                                     </button>
                                   </div>
                                 </div>

--- a/services/dashboard/src/components/dmx/DMXSidebar.tsx
+++ b/services/dashboard/src/components/dmx/DMXSidebar.tsx
@@ -264,7 +264,7 @@ export function DMXSidebar({
 
   return (
     <>
-    <aside className="w-full md:w-[295px] md:shrink-0 bg-slate-900 md:border-l border-slate-800 flex flex-col overflow-hidden">
+    <aside className="w-full md:w-sidebar-dmx md:shrink-0 bg-slate-900 md:border-l border-slate-800 flex flex-col overflow-hidden">
 
       {/* ── Art-Net Nodes section ───────────────────────────────────── */}
       <div className="flex flex-col shrink-0" style={{ transition: 'flex 350ms cubic-bezier(0.4,0,0.2,1)' }}>

--- a/services/dashboard/src/components/dmx/DMXSidebar.tsx
+++ b/services/dashboard/src/components/dmx/DMXSidebar.tsx
@@ -511,7 +511,7 @@ export function DMXSidebar({
                                 {/* Row 1: grip · name · actions */}
                                 <div className="flex items-center gap-1">
                                   <GripVertical className="w-3 h-3 text-slate-700 group-hover:text-slate-500 transition-colors shrink-0 cursor-grab active:cursor-grabbing" />
-                                  <div className="text-xs font-medium text-slate-200 truncate flex-1">{fixture.label || fixture.name}</div>
+                                  <div className="text-xs font-medium text-slate-200 truncate flex-1">{fixture.name}</div>
                                   {/* Action buttons: always visible on mobile, hover-only on desktop */}
                                   <div className="flex items-center gap-1 shrink-0 md:opacity-0 md:group-hover:opacity-100 transition-opacity">
                                     <button

--- a/services/dashboard/src/components/dmx/DeleteFixtureDialog.tsx
+++ b/services/dashboard/src/components/dmx/DeleteFixtureDialog.tsx
@@ -20,8 +20,8 @@ export function DeleteFixtureDialog({ fixture, onConfirm, onCancel }: DeleteFixt
   }
 
   return (
-    <div className="fixed inset-0 z-50 flex items-center justify-center bg-black/60 backdrop-blur-sm">
-      <div className="w-full max-w-sm bg-slate-900 border border-slate-700 rounded-xl shadow-2xl">
+    <div className="modal-backdrop">
+      <div className="modal-panel max-w-sm">
         <div className="flex items-center justify-between px-5 py-4 border-b border-slate-800">
           <div className="flex items-center gap-2">
             <Trash2 className="w-4 h-4 text-red-400" />

--- a/services/dashboard/src/components/dmx/FixtureNode.tsx
+++ b/services/dashboard/src/components/dmx/FixtureNode.tsx
@@ -38,7 +38,7 @@ export function FixtureNode({
 }: FixtureNodeProps) {
   const [hovered, setHovered] = useState(false)
   const color = universeColor
-  const displayName = fixture.label || fixture.name
+  const displayName = fixture.name
   const shortId = fixture.id.replace(/-/g, '').slice(0, 7)
 
   const radius = Math.round(diameter / 2)

--- a/services/dashboard/src/components/icons.ts
+++ b/services/dashboard/src/components/icons.ts
@@ -111,6 +111,8 @@ export {
   RotateCcw,
   ZapOff,
   Undo2,
+  Move,
+  Crosshair,
 } from 'lucide-react'
 
 // Device type icon lookup

--- a/services/dashboard/src/components/icons.ts
+++ b/services/dashboard/src/components/icons.ts
@@ -91,6 +91,7 @@ export {
   Pencil,
   Trash2,
   X,
+  Menu,
   ChevronRight,
   Search,
   RefreshCw,

--- a/services/dashboard/src/lib/types.ts
+++ b/services/dashboard/src/lib/types.ts
@@ -513,7 +513,6 @@ export interface ChannelMapping {
 export interface DMXFixture {
   id: string
   name: string
-  label?: string
   ofl_manufacturer?: string
   ofl_model?: string
   node_id: string
@@ -537,7 +536,6 @@ export interface DMXFixture {
 
 export interface DMXFixtureCreate {
   name: string
-  label?: string
   node_id: string
   universe: number
   start_channel: number
@@ -556,7 +554,6 @@ export interface DMXFixtureCreate {
 
 export interface DMXFixtureUpdate {
   name?: string
-  label?: string
   node_id?: string
   universe?: number
   start_channel?: number

--- a/services/dashboard/tailwind.config.js
+++ b/services/dashboard/tailwind.config.js
@@ -10,6 +10,12 @@ module.exports = {
       fontFamily: {
         mono: ['"JetBrains Mono"', 'ui-monospace', 'SFMono-Regular', 'monospace'],
       },
+      width: {
+        // Named sidebar widths — values come from CSS custom properties in globals.css
+        // so a single source of truth controls both Tailwind classes and inline styles.
+        'sidebar-nav': 'var(--sidebar-nav-width)',  // left navigation drawer (14rem / 224px)
+        'sidebar-dmx': 'var(--sidebar-dmx-width)',  // DMX Lighting right panel (295px)
+      },
     },
   },
   plugins: [],

--- a/services/fleet-manager/dmx_router.py
+++ b/services/fleet-manager/dmx_router.py
@@ -190,7 +190,6 @@ class DMXGroupUpdate(BaseModel):
 
 class DMXFixtureCreate(BaseModel):
     name: str
-    label: Optional[str] = None
     node_id: UUID
     universe: int
     start_channel: int = Field(..., ge=1, le=512)
@@ -212,7 +211,6 @@ class DMXFixtureCreate(BaseModel):
 
 class DMXFixtureUpdate(BaseModel):
     name: Optional[str] = None
-    label: Optional[str] = None
     node_id: Optional[UUID] = None
     universe: Optional[int] = None
     start_channel: Optional[int] = Field(None, ge=1, le=512)
@@ -282,7 +280,6 @@ def _row_to_fixture(row) -> dict:
     return {
         "id": str(row.id),
         "name": row.name,
-        "label": row.label,
         "ofl_manufacturer": getattr(row, "ofl_manufacturer", None),
         "ofl_model": getattr(row, "ofl_model", None),
         "node_id": str(row.node_id),
@@ -793,11 +790,11 @@ async def create_fixture(data: DMXFixtureCreate, db: AsyncSession = Depends(get_
 
     await db.execute(text("""
         INSERT INTO dmx_fixtures (
-            id, name, label, node_id, universe,
+            id, name, node_id, universe,
             start_channel, channel_count, fixture_mode, channel_map,
             entity_id, ofl_fixture_id, group_id, position_x, position_y, sort_order, metadata
         ) VALUES (
-            :id, :name, :label, :node_id, :universe,
+            :id, :name, :node_id, :universe,
             :start_channel, :channel_count, :fixture_mode, CAST(:channel_map AS jsonb),
             :entity_id, :ofl_fixture_id, :group_id, :position_x, :position_y,
             COALESCE((SELECT MAX(sort_order) + 1 FROM dmx_fixtures), 0),
@@ -806,7 +803,6 @@ async def create_fixture(data: DMXFixtureCreate, db: AsyncSession = Depends(get_
     """), {
         "id": fixture_id,
         "name": data.name,
-        "label": data.label,
         "node_id": str(data.node_id),
         "universe": data.universe,
         "start_channel": data.start_channel,


### PR DESCRIPTION
## Summary

- **Mobile-responsive layout** — hamburger nav with slide-in sidebar, DMX page canvas hidden on mobile with full-width sidebar, toolbar condensed to icon-only labels, per-fixture Adjust button always visible on mobile
- **Centralized design tokens** — breakpoints, sidebar widths, modal styles defined once in `globals.css` + `tailwind.config.js` and referenced everywhere
- **Mobile dashboard** — toggle between dashboard summary and Live Activity feed on small screens
- **Mobile header health indicators** — system service status dots with identifying icons (Server, MessageSquare, Database, Cloud, Wifi) in the AppShell mobile top bar
- **Entity display name editing** — "Name" field in entity detail edit form renamed to "Display Name" with slug-unchanged hint for clarity
- **Fixture name → entity name sync** — editing a fixture's name in AddFixtureModal now also updates the linked entity's display name
- **Remove Short Label** — `label` field removed from the DMX fixture create/edit form, canvas display, sidebar, entity detail card, API models, TypeScript types, and database (migration 021)
- **Fix auto-numbering** — `allFixtureNames` was always empty; now correctly populated from the `fixtures` prop so OFL model name increments work against existing fixtures
- **OFL submodule** — updated from feature branch to `master` on fork

## Changed Files

| Area | Files |
|------|-------|
| Mobile layout | `AppShell.tsx`, `Sidebar.tsx`, `app/dmx/page.tsx`, `globals.css`, `tailwind.config.js` |
| Dashboard | `app/page.tsx`, `icons.ts` |
| Entity editing | `app/entities/[id]/page.tsx` |
| DMX components | `AddFixtureModal.tsx`, `DMXSidebar.tsx`, `DMXChannelModal.tsx`, `FixtureNode.tsx`, `DeleteFixtureDialog.tsx` |
| Backend | `services/fleet-manager/dmx_router.py` |
| Types | `services/dashboard/src/lib/types.ts` |
| Migration | `config/postgres/migrations/021_drop_dmx_fixture_label.sql` |
| Submodule | `vendor/ofl`, `.gitmodules` |

## Database Migration

Run `make migrate` after deploying — migration 021 drops the now-unused `label` column from `dmx_fixtures`. Idempotent (`IF EXISTS`), safe on fresh installs.

## Test Plan

- [ ] Mobile nav: hamburger opens/closes sidebar; nav links dismiss drawer
- [ ] DMX mobile: canvas hidden, sidebar full-width, all tabs accessible, Adjust button visible without hover
- [ ] Entity detail: editing display name saves correctly; slug remains unchanged in header
- [ ] Fixture edit: changing fixture name also updates linked entity's display name
- [ ] DMX create: OFL model auto-numbering increments correctly (e.g. adding a second "PAR 56" yields "PAR 56 2")
- [ ] No "Short Label" field appears anywhere in the fixture create/edit flow
- [ ] Status dots in mobile header show correct icons and colors
- [ ] `make migrate` runs cleanly on an existing database

🤖 Generated with [Claude Code](https://claude.com/claude-code)