### PR TITLE
feat: live ambient console visualization

### DIFF
--- a/services/dashboard/src/components/console/AmbientCanvas.tsx
+++ b/services/dashboard/src/components/console/AmbientCanvas.tsx
@@ -27,6 +27,9 @@ const BACKGROUND = '#0a0a0f'
 const MAX_PARTICLES = 250
 const PARTICLE_LIFETIME = 1100 // ms
 const HEAT_DECAY = 0.35        // heat units/second — full decay in ~3s
+const DRIFT_OUT   = 15         // px/s outward when cold
+const DRIFT_IN    = 100        // px/s inward per unit of heat
+const DRIFT_MAX   = 1.65       // max driftRadius as multiple of baseRadius
 
 function rgba(r: number, g: number, b: number, a: number): string {
   return `rgba(${r},${g},${b},${a})`
@@ -45,6 +48,10 @@ interface AmbientNode {
   breathPhase: number
   heat: number        // 0–1, amplifies glow
   lastActivity: number
+  // Drift system (entity / device / artnet only)
+  baseAngle: number   // fixed angle from center set at layout time
+  baseRadius: number  // inner boundary — minimum distance from center
+  driftRadius: number // current distance; drifts out when cold, pulled in by heat
 }
 
 interface Particle {
@@ -198,10 +205,21 @@ export function AmbientCanvas() {
     const existing = new Map<string, AmbientNode>()
     for (const n of ambientNodesRef.current) existing.set(n.id, n)
 
-    const makeNode = (n: GraphNode, x: number, y: number, r: number): AmbientNode => {
+    const makeNode = (
+      n: GraphNode, x: number, y: number, r: number,
+      angle = 0, baseRadius = 0,
+    ): AmbientNode => {
       const ex = existing.get(n.id)
       if (ex) {
-        ex.x = x; ex.y = y; ex.radius = r
+        ex.radius = r
+        // Non-drifting nodes (bus, gateway): just update position
+        if (baseRadius === 0) { ex.x = x; ex.y = y }
+        // Drifting nodes: update base geometry; keep driftRadius if already further out
+        else {
+          ex.baseAngle = angle
+          ex.baseRadius = baseRadius
+          if (ex.driftRadius < baseRadius) ex.driftRadius = baseRadius
+        }
         return ex
       }
       return {
@@ -209,6 +227,7 @@ export function AmbientCanvas() {
         x, y, radius: r, targetRadius: r,
         breathPhase: Math.random() * Math.PI * 2,
         heat: 0, lastActivity: 0,
+        baseAngle: angle, baseRadius, driftRadius: baseRadius,
       }
     }
 
@@ -234,10 +253,11 @@ export function AmbientCanvas() {
     const outerR = Math.min(width, height) * 0.38
     rest.forEach((n, i) => {
       const angle = (i / Math.max(rest.length, 1)) * Math.PI * 2 - Math.PI / 2
+      // Pass angle + baseRadius so the render loop can drive drift position
       result.push(makeNode(n,
         cx + Math.cos(angle) * outerR,
         cy + Math.sin(angle) * outerR,
-        7,
+        7, angle, outerR,
       ))
     })
 
@@ -375,7 +395,7 @@ export function AmbientCanvas() {
       ctx.fillStyle = BACKGROUND
       ctx.fillRect(0, 0, w, h)
       const bgGrad = ctx.createRadialGradient(w / 2, h / 2, 0, w / 2, h / 2, Math.max(w, h) * 0.6)
-      bgGrad.addColorStop(0, '#0b0b1e')
+      bgGrad.addColorStop(0, '#18183a')
       bgGrad.addColorStop(1, BACKGROUND)
       ctx.fillStyle = bgGrad
       ctx.fillRect(0, 0, w, h)
@@ -415,10 +435,25 @@ export function AmbientCanvas() {
         idleRingsRef.current = []
       }
 
+      const cx = w / 2
+      const cy = h / 2
+
       // Nodes
       for (const node of an) {
         // Heat decay
         node.heat = Math.max(0, node.heat - HEAT_DECAY * dt)
+
+        // Drift: entity / device / artnet nodes move outward when cold,
+        // pulled back toward their inner boundary (baseRadius) by heat.
+        if (node.baseRadius > 0) {
+          const net = DRIFT_OUT - DRIFT_IN * node.heat
+          node.driftRadius = Math.min(
+            node.baseRadius * DRIFT_MAX,
+            Math.max(node.baseRadius, node.driftRadius + net * dt),
+          )
+          node.x = cx + Math.cos(node.baseAngle) * node.driftRadius
+          node.y = cy + Math.sin(node.baseAngle) * node.driftRadius
+        }
 
         // Ease targetRadius back to base
         const baseR = node.radius

--- a/services/dashboard/src/components/console/AmbientCanvas.tsx
+++ b/services/dashboard/src/components/console/AmbientCanvas.tsx
@@ -395,22 +395,6 @@ export function AmbientCanvas() {
         }
       }
 
-      // Topology lines: DMX gateway ↔ each Art-Net node (output path)
-      const dmxGateway = an.find(n => n.id === 'gateway-dmx')
-      if (dmxGateway) {
-        for (const node of an) {
-          if (node.type !== 'artnet') continue
-          const lineAlpha = 0.05 + node.heat * 0.2
-          ctx.beginPath()
-          ctx.moveTo(dmxGateway.x, dmxGateway.y)
-          ctx.lineTo(node.x, node.y)
-          ctx.strokeStyle = rgba(251, 191, 36, lineAlpha)
-          ctx.lineWidth = 1
-          ctx.setLineDash([3, 5]) // dashed to distinguish from bus lines
-          ctx.stroke()
-          ctx.setLineDash([])
-        }
-      }
 
       // Idle bus rings when message rate < 1 msg/s
       if (mps < 1 && busNode) {
@@ -486,41 +470,9 @@ export function AmbientCanvas() {
           ctx.lineWidth = 1
           ctx.stroke()
 
-        } else if (node.type === 'artnet') {
-          // Art-Net hardware node: amber diamond shape, distinct from round entity nodes
-          const [r, g, b]: RGB = [251, 191, 36] // amber-400
-          if (node.heat > 0.04) {
-            const glowGrad = ctx.createRadialGradient(node.x, node.y, 0, node.x, node.y, drawR * 4)
-            glowGrad.addColorStop(0, rgba(r, g, b, node.heat * 0.5))
-            glowGrad.addColorStop(1, rgba(r, g, b, 0))
-            ctx.beginPath()
-            ctx.arc(node.x, node.y, drawR * 4, 0, Math.PI * 2)
-            ctx.fillStyle = glowGrad
-            ctx.fill()
-          }
-          // Diamond (rotated square)
-          ctx.save()
-          ctx.translate(node.x, node.y)
-          ctx.rotate(Math.PI / 4)
-          ctx.beginPath()
-          ctx.rect(-drawR * 0.75, -drawR * 0.75, drawR * 1.5, drawR * 1.5)
-          ctx.fillStyle = rgba(r, g, b, 0.25 + node.heat * 0.4)
-          ctx.fill()
-          ctx.strokeStyle = rgba(r, g, b, 0.75 + node.heat * 0.25)
-          ctx.lineWidth = 1
-          ctx.stroke()
-          ctx.restore()
-          // IP address as sub-label
-          if (node.slug) {
-            ctx.fillStyle = rgba(r, g, b, 0.2 + node.heat * 0.3)
-            ctx.font = '7px ui-monospace, monospace'
-            ctx.textAlign = 'center'
-            ctx.fillText(node.slug, node.x, node.y + drawR + 22)
-          }
-
         } else {
-          // Device (blue) or entity (green)
-          const [r, g, b]: RGB = node.type === 'device' ? [96, 165, 250] : [52, 211, 153]
+          // Device / Art-Net node (blue) or entity (green)
+          const [r, g, b]: RGB = (node.type === 'device' || node.type === 'artnet') ? [96, 165, 250] : [52, 211, 153]
           if (node.heat > 0.08) {
             const glowGrad = ctx.createRadialGradient(node.x, node.y, 0, node.x, node.y, drawR * 3.5)
             glowGrad.addColorStop(0, rgba(r, g, b, node.heat * 0.4))
@@ -540,8 +492,7 @@ export function AmbientCanvas() {
         const labelAlpha =
           node.type === 'bus'     ? 0.6 + node.heat * 0.35 :
           node.type === 'gateway' ? 0.55 + node.heat * 0.4 :
-          node.type === 'artnet'  ? 0.45 + node.heat * 0.5 :
-          /* entity / device */     0.28 + node.heat * 0.65
+          /* entity / device / artnet */ 0.28 + node.heat * 0.65
         ctx.fillStyle = rgba(148, 163, 184, labelAlpha)
         ctx.font = `${node.type === 'bus' ? 11 : 9}px system-ui, sans-serif`
         ctx.textAlign = 'center'

--- a/services/dashboard/src/components/console/AmbientCanvas.tsx
+++ b/services/dashboard/src/components/console/AmbientCanvas.tsx
@@ -70,6 +70,25 @@ interface Particle {
   onArrive: (() => void) | null
 }
 
+// Cool (blue) → violet → warm (orange) color ramp for the bus heat glow
+function coolToWarm(t: number): RGB {
+  // Two-segment interpolation so the midpoint passes through violet/purple
+  if (t < 0.5) {
+    const s = t / 0.5
+    return [
+      Math.round(25  + s * 95),   // 25  → 120
+      Math.round(55  - s * 35),   // 55  → 20
+      Math.round(190 - s * 30),   // 190 → 160
+    ]
+  }
+  const s = (t - 0.5) / 0.5
+  return [
+    Math.round(120 + s * 110),  // 120 → 230
+    Math.round(20  + s * 65),   // 20  → 85
+    Math.round(160 - s * 145),  // 160 → 15
+  ]
+}
+
 function makeParticle(): Particle {
   return {
     active: false,
@@ -100,6 +119,11 @@ export function AmbientCanvas() {
   const statsRef = useRef(stats)
   const lastRenderTimeRef = useRef(0)
   const idleRingsRef = useRef<Array<{ startTime: number; x: number; y: number }>>([])
+  // MPS history for bus heat calibration (one sample/second, 5-min rolling window)
+  const mpsHistoryRef    = useRef<number[]>([])
+  const lastSampleTimeRef = useRef(0)
+  const busHeatRef       = useRef(0)   // smoothed 0-1 used for glow
+  const busHeatTargetRef = useRef(0.5) // target derived from calibrated range
 
   // Keep statsRef current so the render loop never reads stale values
   useEffect(() => { statsRef.current = stats }, [stats])
@@ -390,6 +414,27 @@ export function AmbientCanvas() {
       const busNode = an.find(n => n.type === 'bus')
       const mps = statsRef.current.messagesPerSecond
 
+      // --- Bus heat calibration (1 sample/second, 5-min rolling window) ---
+      if (now - lastSampleTimeRef.current >= 1000) {
+        lastSampleTimeRef.current = now
+        mpsHistoryRef.current.push(mps)
+        if (mpsHistoryRef.current.length > 300) mpsHistoryRef.current.shift()
+
+        const hist = mpsHistoryRef.current
+        if (hist.length >= 3) {
+          const sorted = [...hist].sort((a, b) => a - b)
+          // Use 10th–90th percentile range to ignore brief outlier spikes/drops
+          const lo = sorted[Math.floor(sorted.length * 0.10)]
+          const hi = sorted[Math.floor(sorted.length * 0.90)]
+          const range = hi - lo
+          busHeatTargetRef.current = range < 0.5
+            ? 0.5 // not enough data yet — sit at midpoint
+            : Math.max(0, Math.min(1, (mps - lo) / range))
+        }
+      }
+      // Smooth toward target (~3s time constant)
+      busHeatRef.current += (busHeatTargetRef.current - busHeatRef.current) * Math.min(1, dt * 0.35)
+
       // Background
       ctx.fillStyle = BACKGROUND
       ctx.fillRect(0, 0, w, h)
@@ -455,6 +500,31 @@ export function AmbientCanvas() {
         ctx.strokeStyle = rgba(148, 163, 184, 0.06)
         ctx.lineWidth = 1
         ctx.stroke()
+      }
+
+      // --- Bus background heat glow (cool → warm based on calibrated MPS) ---
+      if (busNode) {
+        const bh = busHeatRef.current
+        const [gr, gg, gb] = coolToWarm(bh)
+        // Two concentric layers: large soft halo + tighter inner bloom
+        const haloR = 160 + bh * 90
+        const halo = ctx.createRadialGradient(busNode.x, busNode.y, 0, busNode.x, busNode.y, haloR)
+        halo.addColorStop(0,   rgba(gr, gg, gb, 0.14 + bh * 0.10))
+        halo.addColorStop(0.45, rgba(gr, gg, gb, 0.05 + bh * 0.05))
+        halo.addColorStop(1,   rgba(gr, gg, gb, 0))
+        ctx.beginPath()
+        ctx.arc(busNode.x, busNode.y, haloR, 0, Math.PI * 2)
+        ctx.fillStyle = halo
+        ctx.fill()
+
+        const bloomR = 60 + bh * 30
+        const bloom = ctx.createRadialGradient(busNode.x, busNode.y, 0, busNode.x, busNode.y, bloomR)
+        bloom.addColorStop(0,  rgba(gr, gg, gb, 0.10 + bh * 0.12))
+        bloom.addColorStop(1,  rgba(gr, gg, gb, 0))
+        ctx.beginPath()
+        ctx.arc(busNode.x, busNode.y, bloomR, 0, Math.PI * 2)
+        ctx.fillStyle = bloom
+        ctx.fill()
       }
 
       // Nodes

--- a/services/dashboard/src/components/console/AmbientCanvas.tsx
+++ b/services/dashboard/src/components/console/AmbientCanvas.tsx
@@ -456,17 +456,15 @@ export function AmbientCanvas() {
           ctx.fill()
         }
 
-        // Labels: always for bus/gateway; fade in for entities/devices based on heat
-        const isFixed = node.type === 'bus' || node.type === 'gateway'
-        const labelAlpha = isFixed
-          ? 0.5 + node.heat * 0.4
-          : Math.min(1, node.heat * 2.5)
-        if (labelAlpha > 0.02) {
-          ctx.fillStyle = rgba(148, 163, 184, labelAlpha)
-          ctx.font = `${node.type === 'bus' ? 11 : 9}px system-ui, sans-serif`
-          ctx.textAlign = 'center'
-          ctx.fillText(node.label, node.x, node.y + drawR + 13)
-        }
+        // Labels: always visible — bus/gateway bright, entities/devices dim when cold
+        const labelAlpha =
+          node.type === 'bus'     ? 0.6 + node.heat * 0.35 :
+          node.type === 'gateway' ? 0.55 + node.heat * 0.4 :
+          /* entity / device */     0.28 + node.heat * 0.65
+        ctx.fillStyle = rgba(148, 163, 184, labelAlpha)
+        ctx.font = `${node.type === 'bus' ? 11 : 9}px system-ui, sans-serif`
+        ctx.textAlign = 'center'
+        ctx.fillText(node.label, node.x, node.y + drawR + 13)
       }
 
       // Particles

--- a/services/dashboard/src/components/console/AmbientCanvas.tsx
+++ b/services/dashboard/src/components/console/AmbientCanvas.tsx
@@ -270,15 +270,10 @@ export function AmbientCanvas() {
         const busNode = an.find(n => n.type === 'bus')
         if (!busNode) continue
 
-        const color = PROTOCOL_COLORS[msg.protocol] ?? PROTOCOL_COLORS.internal
-
-        // Internal messages: ripple from bus only
-        if (msg.protocol === 'internal') {
-          spawnRipple(busNode, color)
-          continue
-        }
-
-        // Determine source gateway node
+        // Determine source gateway node.
+        // Entity state subjects (maestra.entity.state.*) are classified as 'internal'
+        // by detectProtocol, but resolveSourceTarget may have resolved a real gateway
+        // via the payload's source field — so always check msg.sourceNode first.
         const gatewayId: string | null =
           msg.sourceNode ??
           (msg.protocol === 'osc'  ? 'gateway-osc'  :
@@ -288,6 +283,12 @@ export function AmbientCanvas() {
 
         const gatewayNode = gatewayId ? an.find(n => n.id === gatewayId) : null
         const targetNode  = msg.targetNode ? an.find(n => n.id === msg.targetNode) : null
+
+        // Use the gateway's color so entity state routed via MQTT shows green,
+        // via OSC shows cyan, etc. Fall back to the protocol color.
+        const color: RGB =
+          (gatewayId && GATEWAY_COLORS[gatewayId]) ? GATEWAY_COLORS[gatewayId]
+          : PROTOCOL_COLORS[msg.protocol] ?? PROTOCOL_COLORS.internal
 
         if (gatewayNode) {
           // Two-hop: gateway → bus → entity (or ripple at bus)
@@ -302,7 +303,8 @@ export function AmbientCanvas() {
             }
           })
         } else {
-          spawnRipple(busNode, color)
+          const fallbackColor = PROTOCOL_COLORS[msg.protocol] ?? PROTOCOL_COLORS.internal
+          spawnRipple(busNode, fallbackColor)
         }
       }
     })

--- a/services/dashboard/src/components/console/AmbientCanvas.tsx
+++ b/services/dashboard/src/components/console/AmbientCanvas.tsx
@@ -3,37 +3,36 @@
 import { useRef, useEffect, useCallback, useState } from 'react'
 import { useConsole, type GraphNode, type Protocol } from './ConsoleProvider'
 
-// --- Protocol colors (more saturated for ambient) ---
-const PARTICLE_COLORS: Record<Protocol, string> = {
-  osc: '#22d3ee',
-  mqtt: '#34d399',
-  ws: '#a78bfa',
-  internal: '#cbd5e1',
+// --- Color types & palettes ---
+
+type RGB = [number, number, number]
+
+const PROTOCOL_COLORS: Record<Protocol, RGB> = {
+  osc:      [34,  211, 238], // cyan-400
+  mqtt:     [52,  211, 153], // emerald-400
+  ws:       [167, 139, 250], // violet-400
+  dmx:      [251, 191,  36], // amber-400
+  internal: [148, 163, 184], // slate-400
 }
 
-const NODE_COLOR = 'rgba(148, 163, 184, 0.6)' // slate-400
-const BUS_COLOR = 'rgba(148, 163, 184, 0.3)'
+// Per-gateway node color (by node ID)
+const GATEWAY_COLORS: Record<string, RGB> = {
+  'gateway-osc':  [34,  211, 238],
+  'gateway-mqtt': [52,  211, 153],
+  'gateway-ws':   [167, 139, 250],
+  'gateway-dmx':  [251, 191,  36],
+}
+
 const BACKGROUND = '#0a0a0f'
+const MAX_PARTICLES = 250
+const PARTICLE_LIFETIME = 1100 // ms
+const HEAT_DECAY = 0.35        // heat units/second — full decay in ~3s
 
-// --- Particle system ---
-interface Particle {
-  active: boolean
-  x: number
-  y: number
-  targetX: number
-  targetY: number
-  startX: number
-  startY: number
-  controlX: number
-  controlY: number
-  color: string
-  progress: number // 0 to 1
-  lifetime: number // ms
-  startTime: number
-  trail: Array<{ x: number; y: number }>
-  isRipple: boolean
-  rippleRadius: number
+function rgba(r: number, g: number, b: number, a: number): string {
+  return `rgba(${r},${g},${b},${a})`
 }
+
+// --- Node & Particle types ---
 
 interface AmbientNode {
   id: string
@@ -44,10 +43,45 @@ interface AmbientNode {
   radius: number
   targetRadius: number
   breathPhase: number
+  heat: number        // 0–1, amplifies glow
+  lastActivity: number
 }
 
-const MAX_PARTICLES = 200
-const PARTICLE_LIFETIME = 1500
+interface Particle {
+  active: boolean
+  startX: number; startY: number
+  targetX: number; targetY: number
+  controlX: number; controlY: number
+  x: number; y: number
+  color: RGB
+  size: number
+  lifetime: number
+  startTime: number
+  trail: Array<{ x: number; y: number }>
+  isRipple: boolean
+  rippleRadius: number
+  arrivedFired: boolean
+  onArrive: (() => void) | null
+}
+
+function makeParticle(): Particle {
+  return {
+    active: false,
+    startX: 0, startY: 0, targetX: 0, targetY: 0,
+    controlX: 0, controlY: 0, x: 0, y: 0,
+    color: [148, 163, 184],
+    size: 3,
+    lifetime: PARTICLE_LIFETIME,
+    startTime: 0,
+    trail: [],
+    isRipple: false,
+    rippleRadius: 0,
+    arrivedFired: false,
+    onArrive: null,
+  }
+}
+
+// --- Component ---
 
 export function AmbientCanvas() {
   const { nodes, messages, subscribe, stats } = useConsole()
@@ -55,32 +89,16 @@ export function AmbientCanvas() {
   const animRef = useRef<number>(0)
   const particlesRef = useRef<Particle[]>([])
   const ambientNodesRef = useRef<AmbientNode[]>([])
-  const glowSpritesRef = useRef<Map<string, HTMLCanvasElement>>(new Map())
   const lastMsgCountRef = useRef(0)
   const samplingCounterRef = useRef(0)
+  const statsRef = useRef(stats)
+  const lastRenderTimeRef = useRef(0)
+  const idleRingsRef = useRef<Array<{ startTime: number; x: number; y: number }>>([])
 
-  // Create glow sprite for a given color
-  const createGlowSprite = useCallback((color: string, radius: number): HTMLCanvasElement => {
-    const sprite = document.createElement('canvas')
-    const size = radius * 4
-    sprite.width = size
-    sprite.height = size
-    const ctx = sprite.getContext('2d')!
-    const gradient = ctx.createRadialGradient(size / 2, size / 2, 0, size / 2, size / 2, radius * 1.5)
-    gradient.addColorStop(0, color)
-    // Parse color and create faded version
-    const match = color.match(/rgba?\((\d+),\s*(\d+),\s*(\d+)/)
-    const fadedColor = match
-      ? `rgba(${match[1]}, ${match[2]}, ${match[3]}, 0.15)`
-      : 'rgba(148, 163, 184, 0.15)'
-    gradient.addColorStop(0.5, fadedColor)
-    gradient.addColorStop(1, 'transparent')
-    ctx.fillStyle = gradient
-    ctx.fillRect(0, 0, size, size)
-    return sprite
-  }, [])
+  // Keep statsRef current so the render loop never reads stale values
+  useEffect(() => { statsRef.current = stats }, [stats])
 
-  // Track canvas dimensions via ResizeObserver
+  // Track canvas size for layout recalculation
   const [canvasSize, setCanvasSize] = useState({ width: 800, height: 600 })
   useEffect(() => {
     const canvas = canvasRef.current
@@ -91,89 +109,143 @@ export function AmbientCanvas() {
       }
     })
     observer.observe(canvas)
-    // Initial size
     setCanvasSize({ width: canvas.clientWidth || 800, height: canvas.clientHeight || 600 })
     return () => observer.disconnect()
   }, [])
 
-  // Layout nodes in radial pattern
+  // --- Particle pool ---
+
+  const acquireParticle = useCallback((): Particle => {
+    const pool = particlesRef.current
+    const free = pool.find(p => !p.active)
+    if (free) return free
+    if (pool.length < MAX_PARTICLES) {
+      const p = makeParticle()
+      pool.push(p)
+      return p
+    }
+    // FIFO: evict the oldest active particle
+    return pool.reduce((oldest, p) => p.startTime < oldest.startTime ? p : oldest)
+  }, [])
+
+  const spawnParticle = useCallback((
+    src: AmbientNode,
+    dst: AmbientNode,
+    color: RGB,
+    size: number,
+    onArrive: (() => void) | null,
+  ) => {
+    const p = acquireParticle()
+    const midX = (src.x + dst.x) / 2
+    const midY = (src.y + dst.y) / 2
+    const dx = dst.x - src.x
+    const dy = dst.y - src.y
+    const perpX = -dy * 0.25
+    const perpY = dx * 0.25
+
+    p.active = true
+    p.startX = src.x;    p.startY = src.y
+    p.targetX = dst.x;   p.targetY = dst.y
+    p.controlX = midX + perpX
+    p.controlY = midY + perpY
+    p.x = src.x;         p.y = src.y
+    p.color = color
+    p.size = size
+    p.lifetime = PARTICLE_LIFETIME
+    p.startTime = Date.now()
+    p.trail = []
+    p.isRipple = false
+    p.rippleRadius = 0
+    p.arrivedFired = false
+    p.onArrive = onArrive
+
+    src.heat = Math.min(1, src.heat + 0.35)
+    src.lastActivity = Date.now()
+  }, [acquireParticle])
+
+  const spawnRipple = useCallback((node: AmbientNode, color: RGB) => {
+    const p = acquireParticle()
+    p.active = true
+    p.startX = node.x;  p.startY = node.y
+    p.targetX = node.x; p.targetY = node.y
+    p.controlX = node.x; p.controlY = node.y
+    p.x = node.x;       p.y = node.y
+    p.color = color
+    p.size = 2
+    p.lifetime = PARTICLE_LIFETIME
+    p.startTime = Date.now()
+    p.trail = []
+    p.isRipple = true
+    p.rippleRadius = node.radius
+    p.arrivedFired = false
+    p.onArrive = null
+
+    node.heat = Math.min(1, node.heat + 0.2)
+    node.lastActivity = Date.now()
+  }, [acquireParticle])
+
+  // --- Node layout: preserve heat/activity across re-layouts ---
+
   useEffect(() => {
     if (nodes.length === 0) return
-
-    const width = canvasSize.width
-    const height = canvasSize.height
+    const { width, height } = canvasSize
     if (width < 10 || height < 10) return
-    const centerX = width / 2
-    const centerY = height / 2
 
-    const busNode = nodes.find(n => n.type === 'bus')
-    const otherNodes = nodes.filter(n => n.type !== 'bus')
+    const cx = width / 2
+    const cy = height / 2
 
-    const ambientNodes: AmbientNode[] = []
+    // Build a map so we can reuse existing node objects (preserving heat)
+    const existing = new Map<string, AmbientNode>()
+    for (const n of ambientNodesRef.current) existing.set(n.id, n)
 
-    // Bus at center
-    if (busNode) {
-      ambientNodes.push({
-        id: busNode.id,
-        label: busNode.label,
-        type: busNode.type,
-        x: centerX,
-        y: centerY,
-        radius: 30,
-        targetRadius: 30,
+    const makeNode = (n: GraphNode, x: number, y: number, r: number): AmbientNode => {
+      const ex = existing.get(n.id)
+      if (ex) {
+        ex.x = x; ex.y = y; ex.radius = r
+        return ex
+      }
+      return {
+        id: n.id, label: n.label, type: n.type,
+        x, y, radius: r, targetRadius: r,
         breathPhase: Math.random() * Math.PI * 2,
-      })
+        heat: 0, lastActivity: 0,
+      }
     }
 
-    // Other nodes in concentric rings
-    const gateways = otherNodes.filter(n => n.type === 'gateway')
-    const rest = otherNodes.filter(n => n.type !== 'gateway')
+    const busNode    = nodes.find(n => n.type === 'bus')
+    const gateways   = nodes.filter(n => n.type === 'gateway')
+    const rest       = nodes.filter(n => n.type !== 'bus' && n.type !== 'gateway')
+    const result: AmbientNode[] = []
 
-    // Inner ring: gateways
+    if (busNode) {
+      result.push(makeNode(busNode, cx, cy, 28))
+    }
+
+    const innerR = Math.min(width, height) * 0.22
     gateways.forEach((n, i) => {
       const angle = (i / Math.max(gateways.length, 1)) * Math.PI * 2 - Math.PI / 2
-      const ringRadius = Math.min(width, height) * 0.2
-      ambientNodes.push({
-        id: n.id,
-        label: n.label,
-        type: n.type,
-        x: centerX + Math.cos(angle) * ringRadius,
-        y: centerY + Math.sin(angle) * ringRadius,
-        radius: 12,
-        targetRadius: 12,
-        breathPhase: Math.random() * Math.PI * 2,
-      })
+      result.push(makeNode(n,
+        cx + Math.cos(angle) * innerR,
+        cy + Math.sin(angle) * innerR,
+        10,
+      ))
     })
 
-    // Outer ring: devices and entities
+    const outerR = Math.min(width, height) * 0.38
     rest.forEach((n, i) => {
       const angle = (i / Math.max(rest.length, 1)) * Math.PI * 2 - Math.PI / 2
-      const ringRadius = Math.min(width, height) * 0.35
-      ambientNodes.push({
-        id: n.id,
-        label: n.label,
-        type: n.type,
-        x: centerX + Math.cos(angle) * ringRadius,
-        y: centerY + Math.sin(angle) * ringRadius,
-        radius: 12,
-        targetRadius: 12,
-        breathPhase: Math.random() * Math.PI * 2,
-      })
+      result.push(makeNode(n,
+        cx + Math.cos(angle) * outerR,
+        cy + Math.sin(angle) * outerR,
+        7,
+      ))
     })
 
-    ambientNodesRef.current = ambientNodes
+    ambientNodesRef.current = result
+  }, [nodes, canvasSize])
 
-    // Pre-render glow sprites
-    const sprites = new Map<string, HTMLCanvasElement>()
-    sprites.set('node', createGlowSprite(NODE_COLOR, 12))
-    sprites.set('bus', createGlowSprite(BUS_COLOR, 30))
-    Object.entries(PARTICLE_COLORS).forEach(([key, color]) => {
-      sprites.set(`particle-${key}`, createGlowSprite(color, 5))
-    })
-    glowSpritesRef.current = sprites
-  }, [nodes, canvasSize, createGlowSprite])
+  // --- Subscribe for particle spawning ---
 
-  // Subscribe to new messages for particle spawning
   useEffect(() => {
     return subscribe(() => {
       const msgs = messages.current
@@ -182,255 +254,281 @@ export function AmbientCanvas() {
       const newMsgs = msgs.slice(lastMsgCountRef.current)
       lastMsgCountRef.current = msgs.length
 
-      const rate = stats.messagesPerSecond
+      const rate = statsRef.current.messagesPerSecond
       const shouldSample = rate > 60
 
       for (const msg of newMsgs) {
         if (msg.isDivider || msg.isPauseSummary) continue
 
-        // Probabilistic sampling at high rates
         if (shouldSample) {
           samplingCounterRef.current++
           const skipRate = Math.max(1, Math.floor(rate / 60))
           if (samplingCounterRef.current % skipRate !== 0) continue
         }
 
-        // Find an inactive particle slot
-        let particle = particlesRef.current.find(p => !p.active)
-        if (!particle) {
-          if (particlesRef.current.length < MAX_PARTICLES) {
-            particle = {
-              active: false, x: 0, y: 0, targetX: 0, targetY: 0,
-              startX: 0, startY: 0, controlX: 0, controlY: 0,
-              color: '', progress: 0, lifetime: PARTICLE_LIFETIME,
-              startTime: 0, trail: [], isRipple: false, rippleRadius: 0,
-            }
-            particlesRef.current.push(particle)
-          } else {
-            // FIFO eviction
-            particle = particlesRef.current.reduce((oldest, p) =>
-              p.startTime < oldest.startTime ? p : oldest
-            )
-          }
+        const an = ambientNodesRef.current
+        const busNode = an.find(n => n.type === 'bus')
+        if (!busNode) continue
+
+        const color = PROTOCOL_COLORS[msg.protocol] ?? PROTOCOL_COLORS.internal
+
+        // Internal messages: ripple from bus only
+        if (msg.protocol === 'internal') {
+          spawnRipple(busNode, color)
+          continue
         }
 
-        const ambientNodes = ambientNodesRef.current
-        const sourceNode = msg.sourceNode ? ambientNodes.find(n => n.id === msg.sourceNode) : null
-        const targetNode = msg.targetNode ? ambientNodes.find(n => n.id === msg.targetNode) : null
-        const busNode = ambientNodes.find(n => n.type === 'bus')
+        // Determine source gateway node
+        const gatewayId: string | null =
+          msg.sourceNode ??
+          (msg.protocol === 'osc'  ? 'gateway-osc'  :
+           msg.protocol === 'mqtt' ? 'gateway-mqtt' :
+           msg.protocol === 'ws'   ? 'gateway-ws'   :
+           msg.protocol === 'dmx'  ? 'gateway-dmx'  : null)
 
-        if (sourceNode && targetNode) {
-          // Animate from source to target
-          const midX = (sourceNode.x + targetNode.x) / 2
-          const midY = (sourceNode.y + targetNode.y) / 2
-          const dx = targetNode.x - sourceNode.x
-          const dy = targetNode.y - sourceNode.y
-          const perpX = -dy * 0.3
-          const perpY = dx * 0.3
+        const gatewayNode = gatewayId ? an.find(n => n.id === gatewayId) : null
+        const targetNode  = msg.targetNode ? an.find(n => n.id === msg.targetNode) : null
 
-          particle.active = true
-          particle.startX = sourceNode.x
-          particle.startY = sourceNode.y
-          particle.targetX = targetNode.x
-          particle.targetY = targetNode.y
-          particle.controlX = midX + perpX
-          particle.controlY = midY + perpY
-          particle.x = sourceNode.x
-          particle.y = sourceNode.y
-          particle.color = PARTICLE_COLORS[msg.protocol] || PARTICLE_COLORS.internal
-          particle.progress = 0
-          particle.startTime = Date.now()
-          particle.trail = []
-          particle.isRipple = false
-
-          // Pulse source node
-          sourceNode.targetRadius = 16
-        } else if (sourceNode) {
-          // Ripple from source
-          particle.active = true
-          particle.x = sourceNode.x
-          particle.y = sourceNode.y
-          particle.startX = sourceNode.x
-          particle.startY = sourceNode.y
-          particle.targetX = sourceNode.x
-          particle.targetY = sourceNode.y
-          particle.color = PARTICLE_COLORS[msg.protocol] || PARTICLE_COLORS.internal
-          particle.progress = 0
-          particle.startTime = Date.now()
-          particle.trail = []
-          particle.isRipple = true
-          particle.rippleRadius = sourceNode.radius
-
-          sourceNode.targetRadius = 16
-        } else if (busNode) {
-          // Ripple from bus
-          particle.active = true
-          particle.x = busNode.x
-          particle.y = busNode.y
-          particle.startX = busNode.x
-          particle.startY = busNode.y
-          particle.targetX = busNode.x
-          particle.targetY = busNode.y
-          particle.color = PARTICLE_COLORS[msg.protocol] || PARTICLE_COLORS.internal
-          particle.progress = 0
-          particle.startTime = Date.now()
-          particle.trail = []
-          particle.isRipple = true
-          particle.rippleRadius = 30
+        if (gatewayNode) {
+          // Two-hop: gateway → bus → entity (or ripple at bus)
+          spawnParticle(gatewayNode, busNode, color, 3, () => {
+            busNode.heat = Math.min(1, busNode.heat + 0.08)
+            if (targetNode) {
+              spawnParticle(busNode, targetNode, color, 2.5, () => {
+                spawnRipple(targetNode, color)
+              })
+            } else {
+              spawnRipple(busNode, color)
+            }
+          })
+        } else {
+          spawnRipple(busNode, color)
         }
       }
     })
-  }, [subscribe, messages, stats.messagesPerSecond])
+  }, [subscribe, messages, spawnParticle, spawnRipple])
 
-  // Main animation loop
+  // --- Main render loop (empty deps — all state via refs) ---
+
   useEffect(() => {
     const canvas = canvasRef.current
     if (!canvas) return
-
     const ctx = canvas.getContext('2d')!
     let mounted = true
 
     const resize = () => {
-      canvas.width = canvas.clientWidth * window.devicePixelRatio
-      canvas.height = canvas.clientHeight * window.devicePixelRatio
-      ctx.scale(window.devicePixelRatio, window.devicePixelRatio)
+      const dpr = window.devicePixelRatio || 1
+      canvas.width  = canvas.clientWidth  * dpr
+      canvas.height = canvas.clientHeight * dpr
+      ctx.setTransform(dpr, 0, 0, dpr, 0, 0)
     }
     resize()
     window.addEventListener('resize', resize)
 
-    const render = () => {
+    const render = (timestamp: number) => {
       if (!mounted) return
+
+      const dt = lastRenderTimeRef.current
+        ? Math.min((timestamp - lastRenderTimeRef.current) / 1000, 0.1)
+        : 0.016
+      lastRenderTimeRef.current = timestamp
+
       const now = Date.now()
       const w = canvas.clientWidth
       const h = canvas.clientHeight
+      const an = ambientNodesRef.current
+      const busNode = an.find(n => n.type === 'bus')
+      const mps = statsRef.current.messagesPerSecond
 
-      // Clear with background
+      // Background
       ctx.fillStyle = BACKGROUND
       ctx.fillRect(0, 0, w, h)
-
-      // Subtle radial gradient
-      const bgGrad = ctx.createRadialGradient(w / 2, h / 2, 0, w / 2, h / 2, Math.max(w, h) / 2)
-      bgGrad.addColorStop(0, '#0a0a1a')
+      const bgGrad = ctx.createRadialGradient(w / 2, h / 2, 0, w / 2, h / 2, Math.max(w, h) * 0.6)
+      bgGrad.addColorStop(0, '#0b0b1e')
       bgGrad.addColorStop(1, BACKGROUND)
       ctx.fillStyle = bgGrad
       ctx.fillRect(0, 0, w, h)
 
-      // Draw nodes with breathing glow
-      const ambientNodes = ambientNodesRef.current
-      for (const node of ambientNodes) {
-        // Breathing animation
-        const breathOffset = Math.sin(now / 3000 * Math.PI * 2 + node.breathPhase) * 2
-        const currentRadius = node.radius + breathOffset
-
-        // Ease radius back to default
-        if (node.targetRadius > node.radius) {
-          node.targetRadius = node.radius + (node.targetRadius - node.radius) * 0.9
-          if (node.targetRadius - node.radius < 0.5) node.targetRadius = node.radius
-        }
-
-        const drawRadius = Math.max(currentRadius, node.targetRadius)
-
-        // Glow
-        if (node.type === 'bus') {
-          // Nebula glow for bus
-          for (let i = 3; i >= 0; i--) {
-            ctx.beginPath()
-            ctx.arc(node.x, node.y, drawRadius + i * 10, 0, Math.PI * 2)
-            ctx.fillStyle = `rgba(148, 163, 184, ${0.03 - i * 0.005})`
-            ctx.fill()
-          }
-          // Ring outline
+      // Topology lines: bus ↔ each gateway (always visible, heat-modulated)
+      if (busNode) {
+        for (const node of an) {
+          if (node.type !== 'gateway') continue
+          const [r, g, b] = GATEWAY_COLORS[node.id] ?? [148, 163, 184]
+          const lineAlpha = 0.07 + node.heat * 0.18
           ctx.beginPath()
-          ctx.arc(node.x, node.y, drawRadius, 0, Math.PI * 2)
-          ctx.strokeStyle = 'rgba(148, 163, 184, 0.4)'
-          ctx.lineWidth = 1.5
+          ctx.moveTo(busNode.x, busNode.y)
+          ctx.lineTo(node.x, node.y)
+          ctx.strokeStyle = rgba(r, g, b, lineAlpha)
+          ctx.lineWidth = 1
           ctx.stroke()
-        } else {
-          // Solid glow for other nodes
-          const nodeGrad = ctx.createRadialGradient(node.x, node.y, 0, node.x, node.y, drawRadius * 2)
-          const baseColor = node.type === 'gateway' ? 'rgba(251, 146, 60,' : node.type === 'device' ? 'rgba(96, 165, 250,' : 'rgba(52, 211, 153,'
-          nodeGrad.addColorStop(0, baseColor + '0.8)')
-          nodeGrad.addColorStop(0.5, baseColor + '0.2)')
-          nodeGrad.addColorStop(1, baseColor + '0)')
-          ctx.beginPath()
-          ctx.arc(node.x, node.y, drawRadius * 2, 0, Math.PI * 2)
-          ctx.fillStyle = nodeGrad
-          ctx.fill()
-
-          // Core
-          ctx.beginPath()
-          ctx.arc(node.x, node.y, drawRadius, 0, Math.PI * 2)
-          ctx.fillStyle = baseColor + '0.6)'
-          ctx.fill()
         }
-
-        // Label
-        ctx.fillStyle = 'rgba(148, 163, 184, 0.5)'
-        ctx.font = '10px system-ui, sans-serif'
-        ctx.textAlign = 'center'
-        ctx.fillText(node.label, node.x, node.y + drawRadius + 14)
       }
 
-      // Draw particles
-      for (const particle of particlesRef.current) {
-        if (!particle.active) continue
+      // Idle bus rings when message rate < 1 msg/s
+      if (mps < 1 && busNode) {
+        const lastRing = idleRingsRef.current[idleRingsRef.current.length - 1]
+        if (!lastRing || now - lastRing.startTime > 2000) {
+          idleRingsRef.current.push({ startTime: now, x: busNode.x, y: busNode.y })
+        }
+        idleRingsRef.current = idleRingsRef.current.filter(ring => now - ring.startTime < 4000)
+        for (const ring of idleRingsRef.current) {
+          const t = (now - ring.startTime) / 4000
+          ctx.beginPath()
+          ctx.arc(ring.x, ring.y, busNode.radius + t * 60, 0, Math.PI * 2)
+          ctx.strokeStyle = rgba(148, 163, 184, (1 - t) * 0.12)
+          ctx.lineWidth = 1
+          ctx.stroke()
+        }
+      } else if (mps >= 1) {
+        idleRingsRef.current = []
+      }
 
-        const elapsed = now - particle.startTime
-        if (elapsed > PARTICLE_LIFETIME) {
-          particle.active = false
+      // Nodes
+      for (const node of an) {
+        // Heat decay
+        node.heat = Math.max(0, node.heat - HEAT_DECAY * dt)
+
+        // Ease targetRadius back to base
+        const baseR = node.radius
+        if (node.targetRadius > baseR) {
+          node.targetRadius = Math.max(baseR, node.targetRadius - (node.targetRadius - baseR) * Math.min(1, dt * 8))
+        } else {
+          node.targetRadius = baseR
+        }
+
+        const breathOffset = Math.sin(now / 3000 * Math.PI * 2 + node.breathPhase) * 1.5
+        const drawR = node.targetRadius + breathOffset + node.heat * 4
+
+        if (node.type === 'bus') {
+          // Multi-layer nebula glow
+          for (let i = 3; i >= 0; i--) {
+            ctx.beginPath()
+            ctx.arc(node.x, node.y, drawR + i * 11 + node.heat * 8, 0, Math.PI * 2)
+            ctx.fillStyle = rgba(148, 163, 184, (0.022 + node.heat * 0.018) / (i + 1))
+            ctx.fill()
+          }
+          ctx.beginPath()
+          ctx.arc(node.x, node.y, drawR, 0, Math.PI * 2)
+          ctx.strokeStyle = rgba(148, 163, 184, 0.35 + node.heat * 0.45)
+          ctx.lineWidth = 1.5
+          ctx.stroke()
+          // Center dot
+          ctx.beginPath()
+          ctx.arc(node.x, node.y, 4, 0, Math.PI * 2)
+          ctx.fillStyle = rgba(148, 163, 184, 0.65 + node.heat * 0.35)
+          ctx.fill()
+
+        } else if (node.type === 'gateway') {
+          const [r, g, b] = GATEWAY_COLORS[node.id] ?? [148, 163, 184]
+          // Heat glow
+          if (node.heat > 0.04) {
+            const glowGrad = ctx.createRadialGradient(node.x, node.y, 0, node.x, node.y, drawR * 4)
+            glowGrad.addColorStop(0, rgba(r, g, b, node.heat * 0.45))
+            glowGrad.addColorStop(1, rgba(r, g, b, 0))
+            ctx.beginPath()
+            ctx.arc(node.x, node.y, drawR * 4, 0, Math.PI * 2)
+            ctx.fillStyle = glowGrad
+            ctx.fill()
+          }
+          ctx.beginPath()
+          ctx.arc(node.x, node.y, drawR, 0, Math.PI * 2)
+          ctx.fillStyle = rgba(r, g, b, 0.5 + node.heat * 0.35)
+          ctx.fill()
+          ctx.strokeStyle = rgba(r, g, b, 0.85 + node.heat * 0.15)
+          ctx.lineWidth = 1
+          ctx.stroke()
+
+        } else {
+          // Device (blue) or entity (green)
+          const [r, g, b]: RGB = node.type === 'device' ? [96, 165, 250] : [52, 211, 153]
+          if (node.heat > 0.08) {
+            const glowGrad = ctx.createRadialGradient(node.x, node.y, 0, node.x, node.y, drawR * 3.5)
+            glowGrad.addColorStop(0, rgba(r, g, b, node.heat * 0.4))
+            glowGrad.addColorStop(1, rgba(r, g, b, 0))
+            ctx.beginPath()
+            ctx.arc(node.x, node.y, drawR * 3.5, 0, Math.PI * 2)
+            ctx.fillStyle = glowGrad
+            ctx.fill()
+          }
+          ctx.beginPath()
+          ctx.arc(node.x, node.y, drawR, 0, Math.PI * 2)
+          ctx.fillStyle = rgba(r, g, b, 0.4 + node.heat * 0.45)
+          ctx.fill()
+        }
+
+        // Labels: always for bus/gateway; fade in for entities/devices based on heat
+        const isFixed = node.type === 'bus' || node.type === 'gateway'
+        const labelAlpha = isFixed
+          ? 0.5 + node.heat * 0.4
+          : Math.min(1, node.heat * 2.5)
+        if (labelAlpha > 0.02) {
+          ctx.fillStyle = rgba(148, 163, 184, labelAlpha)
+          ctx.font = `${node.type === 'bus' ? 11 : 9}px system-ui, sans-serif`
+          ctx.textAlign = 'center'
+          ctx.fillText(node.label, node.x, node.y + drawR + 13)
+        }
+      }
+
+      // Particles
+      for (const p of particlesRef.current) {
+        if (!p.active) continue
+
+        const elapsed = now - p.startTime
+
+        // Fire onArrive just before the particle reaches the target (~92% of lifetime)
+        if (!p.arrivedFired && elapsed >= p.lifetime * 0.92) {
+          p.arrivedFired = true
+          p.onArrive?.()
+        }
+
+        if (elapsed >= p.lifetime) {
+          p.active = false
           continue
         }
 
-        const t = elapsed / PARTICLE_LIFETIME
-        const easeOut = 1 - Math.pow(1 - t, 3)
+        const t = elapsed / p.lifetime
+        const [r, g, b] = p.color
 
-        if (particle.isRipple) {
-          // Expanding ripple
-          const radius = particle.rippleRadius + easeOut * 80
-          const opacity = (1 - t) * 0.4
+        if (p.isRipple) {
+          const radius  = p.rippleRadius + t * 55
           ctx.beginPath()
-          ctx.arc(particle.x, particle.y, radius, 0, Math.PI * 2)
-          ctx.strokeStyle = particle.color
+          ctx.arc(p.x, p.y, radius, 0, Math.PI * 2)
+          ctx.strokeStyle = rgba(r, g, b, (1 - t) * 0.5)
           ctx.lineWidth = 1
-          ctx.globalAlpha = opacity
           ctx.stroke()
-          ctx.globalAlpha = 1
         } else {
-          // Bezier curve particle
-          particle.progress = easeOut
-          const p = particle.progress
-          const invP = 1 - p
-          const newX = invP * invP * particle.startX + 2 * invP * p * particle.controlX + p * p * particle.targetX
-          const newY = invP * invP * particle.startY + 2 * invP * p * particle.controlY + p * p * particle.targetY
+          // Ease-out quadratic Bezier
+          const ease = 1 - Math.pow(1 - t, 2.5)
+          const inv  = 1 - ease
+          const nx = inv * inv * p.startX + 2 * inv * ease * p.controlX + ease * ease * p.targetX
+          const ny = inv * inv * p.startY + 2 * inv * ease * p.controlY + ease * ease * p.targetY
 
-          // Store trail
-          particle.trail.push({ x: newX, y: newY })
-          if (particle.trail.length > 5) particle.trail.shift()
+          p.trail.push({ x: nx, y: ny })
+          if (p.trail.length > 6) p.trail.shift()
+          p.x = nx; p.y = ny
 
-          particle.x = newX
-          particle.y = newY
-
-          // Draw trail
-          const trailOpacities = [0.05, 0.15, 0.3, 0.6, 1.0]
-          for (let i = 0; i < particle.trail.length; i++) {
-            const tp = particle.trail[i]
-            const opacity = trailOpacities[Math.min(i, trailOpacities.length - 1)] * (1 - t * 0.5)
+          const trailAlphas = [0.04, 0.1, 0.22, 0.42, 0.65, 1.0]
+          for (let i = 0; i < p.trail.length; i++) {
+            const tp = p.trail[i]
+            const a  = trailAlphas[Math.min(i, trailAlphas.length - 1)] * (1 - t * 0.4)
+            const ts = p.size * (0.45 + (i / p.trail.length) * 0.55)
             ctx.beginPath()
-            ctx.arc(tp.x, tp.y, 3 + (i / particle.trail.length) * 2, 0, Math.PI * 2)
-            ctx.fillStyle = particle.color
-            ctx.globalAlpha = opacity
+            ctx.arc(tp.x, tp.y, ts, 0, Math.PI * 2)
+            ctx.fillStyle = rgba(r, g, b, a)
             ctx.fill()
           }
-          ctx.globalAlpha = 1
         }
       }
 
-      // Minimal HUD
-      ctx.fillStyle = 'rgba(148, 163, 184, 0.4)'
+      // HUD
+      ctx.fillStyle = rgba(148, 163, 184, 0.28)
       ctx.font = '10px ui-monospace, monospace'
       ctx.textAlign = 'left'
-      const time = new Date().toLocaleTimeString('en-US', { hour12: false })
-      ctx.fillText(`${time}`, 16, h - 16)
+      ctx.fillText(new Date().toLocaleTimeString('en-US', { hour12: false }), 16, h - 16)
+      if (mps > 0) {
+        ctx.textAlign = 'right'
+        ctx.fillText(`${mps} msg/s`, w - 16, h - 16)
+      }
 
       animRef.current = requestAnimationFrame(render)
     }
@@ -442,22 +540,16 @@ export function AmbientCanvas() {
       cancelAnimationFrame(animRef.current)
       window.removeEventListener('resize', resize)
     }
-  }, [])
+  }, []) // empty — all mutable state is accessed via refs
 
-  // Empty state text
   const isEmpty = messages.current.length === 0
 
   return (
     <div className="relative flex-1 bg-[#0a0a0f]">
-      <canvas
-        ref={canvasRef}
-        className="absolute inset-0 w-full h-full"
-      />
+      <canvas ref={canvasRef} className="absolute inset-0 w-full h-full" />
       {isEmpty && (
         <div className="absolute inset-0 flex items-center justify-center pointer-events-none">
-          <span className="text-sm font-mono text-slate-600/30">
-            Waiting for messages...
-          </span>
+          <span className="text-sm font-mono text-slate-600/30">Waiting for messages...</span>
         </div>
       )}
     </div>

--- a/services/dashboard/src/components/console/AmbientCanvas.tsx
+++ b/services/dashboard/src/components/console/AmbientCanvas.tsx
@@ -249,7 +249,7 @@ export function AmbientCanvas() {
       ))
     })
 
-    const outerR = Math.min(width, height) * 0.38
+    const outerR = Math.min(width, height) * 0.32
     rest.forEach((n, i) => {
       const angle = (i / Math.max(rest.length, 1)) * Math.PI * 2 - Math.PI / 2
       // Pass angle + baseRadius so the render loop can drive drift position
@@ -439,7 +439,7 @@ export function AmbientCanvas() {
 
       // Outer drift boundary: keep nodes on screen with margin for labels.
       // Inner boundary (baseRadius) = Math.min(w,h)*0.38 (set at layout time).
-      const outerBoundaryR = Math.min(w, h) * 0.47
+      const outerBoundaryR = Math.min(w, h) * 0.43
 
       // Draw the two boundary rings (very faint — structural guides)
       const innerBoundaryR = an.find(n => n.baseRadius > 0)?.baseRadius

--- a/services/dashboard/src/components/console/AmbientCanvas.tsx
+++ b/services/dashboard/src/components/console/AmbientCanvas.tsx
@@ -84,7 +84,7 @@ function makeParticle(): Particle {
 // --- Component ---
 
 export function AmbientCanvas() {
-  const { nodes, messages, subscribe, stats } = useConsole()
+  const { nodes, messages, subscribe, stats, dmxEntityMap } = useConsole()
   const canvasRef = useRef<HTMLCanvasElement>(null)
   const animRef = useRef<number>(0)
   const particlesRef = useRef<Particle[]>([])
@@ -290,13 +290,42 @@ export function AmbientCanvas() {
           (gatewayId && GATEWAY_COLORS[gatewayId]) ? GATEWAY_COLORS[gatewayId]
           : PROTOCOL_COLORS[msg.protocol] ?? PROTOCOL_COLORS.internal
 
-        if (gatewayNode) {
-          // Two-hop: gateway → bus → entity (or ripple at bus)
+        const dmxColor = PROTOCOL_COLORS.dmx  // amber for Art-Net output
+
+        if (targetNode?.type === 'artnet') {
+          // Art-Net output: DMX gateway → Art-Net node directly (no bus middle hop)
+          // This represents the DMX gateway sending UDP directly to hardware.
+          const dmxGateway = an.find(n => n.id === 'gateway-dmx')
+          if (dmxGateway) {
+            spawnParticle(dmxGateway, targetNode, dmxColor, 3.5, () => {
+              spawnRipple(targetNode, dmxColor)
+            })
+          }
+        } else if (gatewayNode) {
+          // Standard two-hop: gateway → bus → entity (or ripple at bus)
           spawnParticle(gatewayNode, busNode, color, 3, () => {
             busNode.heat = Math.min(1, busNode.heat + 0.08)
             if (targetNode) {
               spawnParticle(busNode, targetNode, color, 2.5, () => {
                 spawnRipple(targetNode, color)
+
+                // If this entity has DMX fixtures, also show the output side:
+                // DMX gateway → Art-Net node fires after entity hop lands
+                const subjectSlug = msg.subject.match(/maestra\.entity\.state\.\w+\.(.+)/)?.[1]
+                if (subjectSlug) {
+                  const artnetIds = dmxEntityMap.current.get(subjectSlug) ?? []
+                  const dmxGateway = an.find(n => n.id === 'gateway-dmx')
+                  if (dmxGateway && artnetIds.length > 0) {
+                    for (const nodeId of artnetIds) {
+                      const artnetNode = an.find(n => n.id === nodeId)
+                      if (artnetNode) {
+                        spawnParticle(dmxGateway, artnetNode, dmxColor, 2.5, () => {
+                          spawnRipple(artnetNode, dmxColor)
+                        })
+                      }
+                    }
+                  }
+                }
               })
             } else {
               spawnRipple(busNode, color)
@@ -363,6 +392,23 @@ export function AmbientCanvas() {
           ctx.strokeStyle = rgba(r, g, b, lineAlpha)
           ctx.lineWidth = 1
           ctx.stroke()
+        }
+      }
+
+      // Topology lines: DMX gateway ↔ each Art-Net node (output path)
+      const dmxGateway = an.find(n => n.id === 'gateway-dmx')
+      if (dmxGateway) {
+        for (const node of an) {
+          if (node.type !== 'artnet') continue
+          const lineAlpha = 0.05 + node.heat * 0.2
+          ctx.beginPath()
+          ctx.moveTo(dmxGateway.x, dmxGateway.y)
+          ctx.lineTo(node.x, node.y)
+          ctx.strokeStyle = rgba(251, 191, 36, lineAlpha)
+          ctx.lineWidth = 1
+          ctx.setLineDash([3, 5]) // dashed to distinguish from bus lines
+          ctx.stroke()
+          ctx.setLineDash([])
         }
       }
 
@@ -440,6 +486,38 @@ export function AmbientCanvas() {
           ctx.lineWidth = 1
           ctx.stroke()
 
+        } else if (node.type === 'artnet') {
+          // Art-Net hardware node: amber diamond shape, distinct from round entity nodes
+          const [r, g, b]: RGB = [251, 191, 36] // amber-400
+          if (node.heat > 0.04) {
+            const glowGrad = ctx.createRadialGradient(node.x, node.y, 0, node.x, node.y, drawR * 4)
+            glowGrad.addColorStop(0, rgba(r, g, b, node.heat * 0.5))
+            glowGrad.addColorStop(1, rgba(r, g, b, 0))
+            ctx.beginPath()
+            ctx.arc(node.x, node.y, drawR * 4, 0, Math.PI * 2)
+            ctx.fillStyle = glowGrad
+            ctx.fill()
+          }
+          // Diamond (rotated square)
+          ctx.save()
+          ctx.translate(node.x, node.y)
+          ctx.rotate(Math.PI / 4)
+          ctx.beginPath()
+          ctx.rect(-drawR * 0.75, -drawR * 0.75, drawR * 1.5, drawR * 1.5)
+          ctx.fillStyle = rgba(r, g, b, 0.25 + node.heat * 0.4)
+          ctx.fill()
+          ctx.strokeStyle = rgba(r, g, b, 0.75 + node.heat * 0.25)
+          ctx.lineWidth = 1
+          ctx.stroke()
+          ctx.restore()
+          // IP address as sub-label
+          if (node.slug) {
+            ctx.fillStyle = rgba(r, g, b, 0.2 + node.heat * 0.3)
+            ctx.font = '7px ui-monospace, monospace'
+            ctx.textAlign = 'center'
+            ctx.fillText(node.slug, node.x, node.y + drawR + 22)
+          }
+
         } else {
           // Device (blue) or entity (green)
           const [r, g, b]: RGB = node.type === 'device' ? [96, 165, 250] : [52, 211, 153]
@@ -458,10 +536,11 @@ export function AmbientCanvas() {
           ctx.fill()
         }
 
-        // Labels: always visible — bus/gateway bright, entities/devices dim when cold
+        // Labels: always visible — bus/gateway bright, others dim when cold
         const labelAlpha =
           node.type === 'bus'     ? 0.6 + node.heat * 0.35 :
           node.type === 'gateway' ? 0.55 + node.heat * 0.4 :
+          node.type === 'artnet'  ? 0.45 + node.heat * 0.5 :
           /* entity / device */     0.28 + node.heat * 0.65
         ctx.fillStyle = rgba(148, 163, 184, labelAlpha)
         ctx.font = `${node.type === 'bus' ? 11 : 9}px system-ui, sans-serif`

--- a/services/dashboard/src/components/console/AmbientCanvas.tsx
+++ b/services/dashboard/src/components/console/AmbientCanvas.tsx
@@ -28,8 +28,7 @@ const MAX_PARTICLES = 250
 const PARTICLE_LIFETIME = 1100 // ms
 const HEAT_DECAY = 0.35        // heat units/second — full decay in ~3s
 const DRIFT_OUT   = 15         // px/s outward when cold
-const DRIFT_IN    = 100        // px/s inward per unit of heat
-const DRIFT_MAX   = 1.65       // max driftRadius as multiple of baseRadius
+const DRIFT_IN    = 220        // px/s inward per unit of heat (net inward when heat > 0.07)
 
 function rgba(r: number, g: number, b: number, a: number): string {
   return `rgba(${r},${g},${b},${a})`
@@ -438,6 +437,26 @@ export function AmbientCanvas() {
       const cx = w / 2
       const cy = h / 2
 
+      // Outer drift boundary: keep nodes on screen with margin for labels.
+      // Inner boundary (baseRadius) = Math.min(w,h)*0.38 (set at layout time).
+      const outerBoundaryR = Math.min(w, h) * 0.47
+
+      // Draw the two boundary rings (very faint — structural guides)
+      const innerBoundaryR = an.find(n => n.baseRadius > 0)?.baseRadius
+      if (innerBoundaryR) {
+        ctx.beginPath()
+        ctx.arc(cx, cy, innerBoundaryR, 0, Math.PI * 2)
+        ctx.strokeStyle = rgba(148, 163, 184, 0.06)
+        ctx.lineWidth = 1
+        ctx.stroke()
+
+        ctx.beginPath()
+        ctx.arc(cx, cy, outerBoundaryR, 0, Math.PI * 2)
+        ctx.strokeStyle = rgba(148, 163, 184, 0.06)
+        ctx.lineWidth = 1
+        ctx.stroke()
+      }
+
       // Nodes
       for (const node of an) {
         // Heat decay
@@ -445,10 +464,11 @@ export function AmbientCanvas() {
 
         // Drift: entity / device / artnet nodes move outward when cold,
         // pulled back toward their inner boundary (baseRadius) by heat.
+        // Clamped strictly between baseRadius and outerBoundaryR.
         if (node.baseRadius > 0) {
           const net = DRIFT_OUT - DRIFT_IN * node.heat
           node.driftRadius = Math.min(
-            node.baseRadius * DRIFT_MAX,
+            outerBoundaryR,
             Math.max(node.baseRadius, node.driftRadius + net * dt),
           )
           node.x = cx + Math.cos(node.baseAngle) * node.driftRadius

--- a/services/dashboard/src/components/console/ConsoleProvider.tsx
+++ b/services/dashboard/src/components/console/ConsoleProvider.tsx
@@ -42,6 +42,7 @@ export interface ConsoleMessage {
 export interface GraphNode {
   id: string
   label: string
+  slug?: string   // entity/device slug used in NATS subjects
   type: 'device' | 'entity' | 'gateway' | 'bus'
   x?: number
   y?: number
@@ -99,7 +100,7 @@ function resolveSourceTarget(
     // Find target entity by slug
     let targetId: string | null = null
     for (const [id, node] of nodeMap) {
-      if (node.label === slug || id === slug) {
+      if (node.slug === slug || node.label === slug || id === slug) {
         targetId = id
         break
       }
@@ -112,7 +113,7 @@ function resolveSourceTarget(
   if (broadcastMatch) {
     const slug = broadcastMatch[2]
     for (const [id, node] of nodeMap) {
-      if (node.label === slug || id === slug) {
+      if (node.slug === slug || node.label === slug || id === slug) {
         return { source: id, target: null }
       }
     }
@@ -267,6 +268,7 @@ export function ConsoleProvider({ children }: { children: React.ReactNode }) {
           graphNodes.push({
             id: e.id,
             label: e.name || e.slug || e.id,
+            slug: e.slug,
             type: 'entity',
             activity: 0,
           })
@@ -428,12 +430,17 @@ export function ConsoleProvider({ children }: { children: React.ReactNode }) {
       () => ({ subject: 'maestra.dmx.fixture.spot_c',       payload: { pan: Math.floor(Math.random() * 255), tilt: Math.floor(Math.random() * 255) } }),
     ]
 
-    // Also target real entity nodes if available
-    const entityNodes = nodes.filter(n => n.type === 'entity').slice(0, 6)
+    // Target all real entities using their slug (the actual NATS subject key)
+    const entityNodes = nodes.filter(n => n.type === 'entity' && (n.slug || n.label))
     entityNodes.forEach(entity => {
+      const subjectSlug = entity.slug || entity.label
+      const sources = ['osc', 'mqtt', 'ws']
       TEMPLATES.push(() => ({
-        subject: `maestra.entity.state.update.${entity.label}`,
-        payload: { state: { brightness: +Math.random().toFixed(2), active: Math.random() > 0.3 }, source: 'mqtt' },
+        subject: `maestra.entity.state.update.${subjectSlug}`,
+        payload: {
+          state: { brightness: +Math.random().toFixed(2), active: Math.random() > 0.3 },
+          source: sources[Math.floor(Math.random() * sources.length)],
+        },
       }))
     })
 

--- a/services/dashboard/src/components/console/ConsoleProvider.tsx
+++ b/services/dashboard/src/components/console/ConsoleProvider.tsx
@@ -127,7 +127,7 @@ function resolveSourceTarget(
   if (artnetMatch) {
     const universe = parseInt(artnetMatch[1])
     for (const [id, node] of nodeMap) {
-      if (node.type === 'artnet' && node.artnetUniverses?.includes(universe)) {
+      if (node.artnetUniverses?.includes(universe)) {
         return { source: 'gateway-dmx', target: id }
       }
     }
@@ -294,16 +294,27 @@ export function ConsoleProvider({ children }: { children: React.ReactNode }) {
         // API unavailable — degrade gracefully
       }
 
-      // Art-Net nodes: physical DMX hardware the DMX gateway sends to
+      // Art-Net nodes: physical DMX hardware the DMX gateway sends to.
+      // If the node has a device_id it's already in graphNodes as a device —
+      // enrich that node with universe info rather than adding a duplicate.
       try {
         const dmxNodes = await dmxApi.listNodes()
         dmxNodes.forEach((n: DMXNode) => {
+          const universes = n.universes.map(u => u.artnet_universe)
+          if (n.device_id) {
+            const existing = graphNodes.find(g => g.id === n.device_id)
+            if (existing) {
+              existing.artnetUniverses = universes
+              return
+            }
+          }
+          // No linked device — add as a standalone artnet node
           graphNodes.push({
             id: `artnet-${n.id}`,
             label: n.name,
             slug: n.id,
             type: 'artnet',
-            artnetUniverses: n.universes.map(u => u.artnet_universe),
+            artnetUniverses: universes,
             activity: 0,
           })
         })

--- a/services/dashboard/src/components/console/ConsoleProvider.tsx
+++ b/services/dashboard/src/components/console/ConsoleProvider.tsx
@@ -4,7 +4,8 @@ import React, { createContext, useContext, useCallback, useEffect, useRef, useSt
 import { useWebSocket } from '@/hooks/useWebSocket'
 import type { WebSocketMessage } from '@/types'
 import type { Device } from '@/types'
-import { api } from '@/lib/api'
+import { api, dmxApi } from '@/lib/api'
+import type { DMXNode, DMXFixture } from '@/lib/types'
 
 // crypto.randomUUID() requires a secure context (HTTPS or localhost).
 // Fall back to a manual implementation for plain HTTP access.
@@ -42,8 +43,9 @@ export interface ConsoleMessage {
 export interface GraphNode {
   id: string
   label: string
-  slug?: string   // entity/device slug used in NATS subjects
-  type: 'device' | 'entity' | 'gateway' | 'bus'
+  slug?: string            // entity/device slug used in NATS subjects
+  type: 'device' | 'entity' | 'gateway' | 'bus' | 'artnet'
+  artnetUniverses?: number[] // Art-Net universe numbers this node handles
   x?: number
   y?: number
   activity: number
@@ -119,10 +121,23 @@ function resolveSourceTarget(
     }
   }
 
+  // Direct Art-Net universe output: maestra.to_artnet.universe.N
+  // Flow: something publishes this → DMX gateway subscribes → sends Art-Net UDP to node
+  const artnetMatch = subject.match(/maestra\.to_artnet\.universe\.(\d+)/)
+  if (artnetMatch) {
+    const universe = parseInt(artnetMatch[1])
+    for (const [id, node] of nodeMap) {
+      if (node.type === 'artnet' && node.artnetUniverses?.includes(universe)) {
+        return { source: 'gateway-dmx', target: id }
+      }
+    }
+    return { source: 'gateway-dmx', target: null }
+  }
+
   // Protocol-prefixed messages
   if (subject.startsWith('maestra.osc.')) return { source: 'gateway-osc', target: null }
   if (subject.startsWith('maestra.mqtt.')) return { source: 'gateway-mqtt', target: null }
-  if (subject.startsWith('maestra.dmx.') || subject.startsWith('maestra.to_artnet.')) return { source: 'gateway-dmx', target: null }
+  if (subject.startsWith('maestra.dmx.')) return { source: 'gateway-dmx', target: null }
 
   return { source: null, target: null }
 }
@@ -181,6 +196,8 @@ interface ConsoleContextValue {
   nodes: GraphNode[]
   simulate: boolean
   setSimulate: (v: boolean) => void
+  // entity_slug → artnet node graph IDs (for DMX output visualisation)
+  dmxEntityMap: React.MutableRefObject<Map<string, string[]>>
   // Actions
   clear: () => void
   subscribe: (cb: () => void) => () => void
@@ -276,6 +293,42 @@ export function ConsoleProvider({ children }: { children: React.ReactNode }) {
       } catch {
         // API unavailable — degrade gracefully
       }
+
+      // Art-Net nodes: physical DMX hardware the DMX gateway sends to
+      try {
+        const dmxNodes = await dmxApi.listNodes()
+        dmxNodes.forEach((n: DMXNode) => {
+          graphNodes.push({
+            id: `artnet-${n.id}`,
+            label: n.name,
+            slug: n.id,
+            type: 'artnet',
+            artnetUniverses: n.universes.map(u => u.artnet_universe),
+            activity: 0,
+          })
+        })
+      } catch {
+        // DMX not configured — degrade gracefully
+      }
+
+      // Build entity_slug → artnet_node_ids map for secondary DMX output animations
+      try {
+        const fixtures = await dmxApi.listFixtures()
+        const entitySlugToNodes = new Map<string, Set<string>>()
+        fixtures.forEach((f: DMXFixture) => {
+          if (f.entity_slug && f.node_id) {
+            const key = f.entity_slug
+            if (!entitySlugToNodes.has(key)) entitySlugToNodes.set(key, new Set())
+            entitySlugToNodes.get(key)!.add(`artnet-${f.node_id}`)
+          }
+        })
+        const map = new Map<string, string[]>()
+        entitySlugToNodes.forEach((ids, slug) => map.set(slug, Array.from(ids)))
+        dmxEntityMapRef.current = map
+      } catch {
+        // Fixtures unavailable — degrade gracefully
+      }
+
       setNodes(graphNodes)
     }
     fetchTopology()
@@ -285,6 +338,8 @@ export function ConsoleProvider({ children }: { children: React.ReactNode }) {
 
   // Build node map for resolution
   const nodeMapRef = useRef(new Map<string, GraphNode>())
+  // entity_slug → artnet node IDs (for secondary DMX output particles)
+  const dmxEntityMapRef = useRef(new Map<string, string[]>())
   useEffect(() => {
     const map = new Map<string, GraphNode>()
     nodes.forEach(n => map.set(n.id, n))
@@ -425,10 +480,29 @@ export function ConsoleProvider({ children }: { children: React.ReactNode }) {
       () => ({ subject: 'maestra.mqtt.maestra.devices.sensor.humidity',    payload: { humidity: +(40 + Math.random() * 30).toFixed(1) } }),
       () => ({ subject: 'maestra.ws.client.interaction',    payload: { x: +Math.random().toFixed(3), y: +Math.random().toFixed(3), type: 'touch' } }),
       () => ({ subject: 'maestra.ws.client.event',          payload: { event: ['click', 'hover', 'scroll'][Math.floor(Math.random() * 3)] } }),
-      () => ({ subject: 'maestra.dmx.fixture.wash_l1',      payload: { value: Math.floor(Math.random() * 255) } }),
-      () => ({ subject: 'maestra.to_artnet.universe.1',     payload: { channel: Math.floor(Math.random() * 512) + 1, value: Math.floor(Math.random() * 255) } }),
-      () => ({ subject: 'maestra.dmx.fixture.spot_c',       payload: { pan: Math.floor(Math.random() * 255), tilt: Math.floor(Math.random() * 255) } }),
+      () => ({ subject: 'maestra.dmx.fixture.wash_l1',  payload: { value: Math.floor(Math.random() * 255) } }),
+      () => ({ subject: 'maestra.dmx.fixture.spot_c',   payload: { pan: Math.floor(Math.random() * 255), tilt: Math.floor(Math.random() * 255) } }),
     ]
+
+    // Art-Net output: use real node universes if available, else fall back to universe 1
+    const artnetNodes = nodes.filter(n => n.type === 'artnet')
+    if (artnetNodes.length > 0) {
+      artnetNodes.forEach(n => {
+        const universes = n.artnetUniverses?.length ? n.artnetUniverses : [1]
+        universes.forEach(u => {
+          TEMPLATES.push(() => ({
+            subject: `maestra.to_artnet.universe.${u}`,
+            payload: { channel: Math.floor(Math.random() * 512) + 1, value: Math.floor(Math.random() * 255) },
+          }))
+        })
+      })
+    } else {
+      // No nodes configured yet — simulate generic universe output
+      TEMPLATES.push(() => ({
+        subject: `maestra.to_artnet.universe.${Math.ceil(Math.random() * 4)}`,
+        payload: { channel: Math.floor(Math.random() * 512) + 1, value: Math.floor(Math.random() * 255) },
+      }))
+    }
 
     // Target all real entities using their slug (the actual NATS subject key)
     const entityNodes = nodes.filter(n => n.type === 'entity' && (n.slug || n.label))
@@ -493,6 +567,7 @@ export function ConsoleProvider({ children }: { children: React.ReactNode }) {
         nodes,
         simulate,
         setSimulate,
+        dmxEntityMap: dmxEntityMapRef,
         clear,
         subscribe,
       }}

--- a/services/dashboard/src/components/console/ConsoleProvider.tsx
+++ b/services/dashboard/src/components/console/ConsoleProvider.tsx
@@ -22,7 +22,7 @@ const generateId = (): string => {
 
 // --- Types ---
 
-export type Protocol = 'osc' | 'mqtt' | 'ws' | 'internal'
+export type Protocol = 'osc' | 'mqtt' | 'ws' | 'dmx' | 'internal'
 
 export interface ConsoleMessage {
   id: string
@@ -70,6 +70,7 @@ function detectProtocol(subject: string): Protocol {
   if (subject.startsWith('maestra.osc.')) return 'osc'
   if (subject.startsWith('maestra.mqtt.')) return 'mqtt'
   if (subject.includes('websocket') || subject.startsWith('maestra.ws.')) return 'ws'
+  if (subject.startsWith('maestra.dmx.') || subject.startsWith('maestra.to_artnet.')) return 'dmx'
   return 'internal'
 }
 
@@ -120,6 +121,7 @@ function resolveSourceTarget(
   // Protocol-prefixed messages
   if (subject.startsWith('maestra.osc.')) return { source: 'gateway-osc', target: null }
   if (subject.startsWith('maestra.mqtt.')) return { source: 'gateway-mqtt', target: null }
+  if (subject.startsWith('maestra.dmx.') || subject.startsWith('maestra.to_artnet.')) return { source: 'gateway-dmx', target: null }
 
   return { source: null, target: null }
 }
@@ -205,7 +207,7 @@ export function ConsoleProvider({ children }: { children: React.ReactNode }) {
   const [paused, setPausedState] = useState(false)
   const [filters, setFilters] = useState<ConsoleFilters>({
     subjectPattern: '',
-    protocols: new Set(['osc', 'mqtt', 'ws', 'internal'] as Protocol[]),
+    protocols: new Set(['osc', 'mqtt', 'ws', 'dmx', 'internal'] as Protocol[]),
     textSearch: '',
     hideHeartbeats: true,
   })
@@ -242,10 +244,11 @@ export function ConsoleProvider({ children }: { children: React.ReactNode }) {
   useEffect(() => {
     const fetchTopology = async () => {
       const graphNodes: GraphNode[] = [
-        { id: 'bus', label: 'NATS Bus', type: 'bus', activity: 0 },
-        { id: 'gateway-osc', label: 'OSC Gateway', type: 'gateway', activity: 0 },
-        { id: 'gateway-mqtt', label: 'MQTT Gateway', type: 'gateway', activity: 0 },
-        { id: 'gateway-ws', label: 'WebSocket', type: 'gateway', activity: 0 },
+        { id: 'bus',          label: 'NATS Bus',     type: 'bus',     activity: 0 },
+        { id: 'gateway-osc',  label: 'OSC',          type: 'gateway', activity: 0 },
+        { id: 'gateway-mqtt', label: 'MQTT',         type: 'gateway', activity: 0 },
+        { id: 'gateway-ws',   label: 'WebSocket',    type: 'gateway', activity: 0 },
+        { id: 'gateway-dmx',  label: 'DMX / Art-Net',type: 'gateway', activity: 0 },
       ]
       try {
         const devices = await api.listDevices()

--- a/services/dashboard/src/components/console/ConsoleProvider.tsx
+++ b/services/dashboard/src/components/console/ConsoleProvider.tsx
@@ -178,6 +178,8 @@ interface ConsoleContextValue {
   stats: ConsoleStats
   isConnected: boolean
   nodes: GraphNode[]
+  simulate: boolean
+  setSimulate: (v: boolean) => void
   // Actions
   clear: () => void
   subscribe: (cb: () => void) => () => void
@@ -204,6 +206,7 @@ export function ConsoleProvider({ children }: { children: React.ReactNode }) {
   const wasConnectedRef = useRef(true)
 
   const [mode, setMode] = useState<ConsoleMode>('debug')
+  const [simulate, setSimulate] = useState(false)
   const [paused, setPausedState] = useState(false)
   const [filters, setFilters] = useState<ConsoleFilters>({
     subjectPattern: '',
@@ -407,6 +410,54 @@ export function ConsoleProvider({ children }: { children: React.ReactNode }) {
     notify()
   }, [notify])
 
+  // Simulation: inject fake messages to demo the ambient visualization
+  useEffect(() => {
+    if (!simulate) return
+
+    const TEMPLATES: Array<() => { subject: string; payload: Record<string, unknown> }> = [
+      () => ({ subject: 'maestra.osc.venue.stage.dimmer',   payload: { value: +Math.random().toFixed(3) } }),
+      () => ({ subject: 'maestra.osc.venue.stage.color',    payload: { r: +Math.random().toFixed(2), g: +Math.random().toFixed(2), b: +Math.random().toFixed(2) } }),
+      () => ({ subject: 'maestra.osc.performer.position',   payload: { x: +Math.random().toFixed(3), y: +Math.random().toFixed(3) } }),
+      () => ({ subject: 'maestra.mqtt.maestra.devices.sensor.temperature', payload: { temperature: +(20 + Math.random() * 10).toFixed(1), unit: 'C' } }),
+      () => ({ subject: 'maestra.mqtt.maestra.devices.controller.button', payload: { id: Math.floor(Math.random() * 8) + 1, state: Math.random() > 0.5 ? 'pressed' : 'released' } }),
+      () => ({ subject: 'maestra.mqtt.maestra.devices.sensor.humidity',    payload: { humidity: +(40 + Math.random() * 30).toFixed(1) } }),
+      () => ({ subject: 'maestra.ws.client.interaction',    payload: { x: +Math.random().toFixed(3), y: +Math.random().toFixed(3), type: 'touch' } }),
+      () => ({ subject: 'maestra.ws.client.event',          payload: { event: ['click', 'hover', 'scroll'][Math.floor(Math.random() * 3)] } }),
+      () => ({ subject: 'maestra.dmx.fixture.wash_l1',      payload: { value: Math.floor(Math.random() * 255) } }),
+      () => ({ subject: 'maestra.to_artnet.universe.1',     payload: { channel: Math.floor(Math.random() * 512) + 1, value: Math.floor(Math.random() * 255) } }),
+      () => ({ subject: 'maestra.dmx.fixture.spot_c',       payload: { pan: Math.floor(Math.random() * 255), tilt: Math.floor(Math.random() * 255) } }),
+    ]
+
+    // Also target real entity nodes if available
+    const entityNodes = nodes.filter(n => n.type === 'entity').slice(0, 6)
+    entityNodes.forEach(entity => {
+      TEMPLATES.push(() => ({
+        subject: `maestra.entity.state.update.${entity.label}`,
+        payload: { state: { brightness: +Math.random().toFixed(2), active: Math.random() > 0.3 }, source: 'mqtt' },
+      }))
+    })
+
+    const interval = setInterval(() => {
+      const count = Math.floor(Math.random() * 3) + 1
+      for (let i = 0; i < count; i++) {
+        const { subject, payload } = TEMPLATES[Math.floor(Math.random() * TEMPLATES.length)]()
+        const protocol = detectProtocol(subject)
+        const { source, target } = resolveSourceTarget(subject, payload, nodeMapRef.current)
+        addMessage({
+          id: generateId(),
+          timestamp: new Date().toISOString(),
+          subject,
+          protocol,
+          payload,
+          sourceNode: source,
+          targetNode: target,
+        })
+      }
+    }, 180)
+
+    return () => clearInterval(interval)
+  }, [simulate, nodes, addMessage])
+
   // Stats update interval
   useEffect(() => {
     const interval = setInterval(() => {
@@ -433,6 +484,8 @@ export function ConsoleProvider({ children }: { children: React.ReactNode }) {
         stats,
         isConnected,
         nodes,
+        simulate,
+        setSimulate,
         clear,
         subscribe,
       }}

--- a/services/dashboard/src/components/console/ConsoleToolbar.tsx
+++ b/services/dashboard/src/components/console/ConsoleToolbar.tsx
@@ -2,7 +2,7 @@
 
 import { useState, useEffect } from 'react'
 import { useConsole, type Protocol } from './ConsoleProvider'
-import { Pause, Play, Trash2, ChevronDown, ChevronUp, Search, Maximize2, Minimize2 } from 'lucide-react'
+import { Pause, Play, Trash2, ChevronDown, ChevronUp, Search, Maximize2, Minimize2, Zap } from 'lucide-react'
 
 const PROTOCOL_COLORS: Record<Protocol, { bg: string; text: string; label: string }> = {
   osc:      { bg: 'bg-cyan-500/20',    text: 'text-cyan-400',    label: 'OSC'  },
@@ -21,6 +21,7 @@ export function ConsoleToolbar({ isFullscreen = false, onToggleFullscreen }: Con
   const {
     mode, setMode, filters, setFilters,
     paused, setPaused, stats, isConnected, clear,
+    simulate, setSimulate,
   } = useConsole()
 
   const [filtersOpen, setFiltersOpen] = useState(false)
@@ -57,6 +58,13 @@ export function ConsoleToolbar({ isFullscreen = false, onToggleFullscreen }: Con
           <span>{stats.messagesPerSecond} msg/s</span>
         </div>
         <div className="flex items-center gap-2">
+          <button
+            onClick={() => setSimulate(!simulate)}
+            title={simulate ? 'Stop simulation' : 'Simulate live data'}
+            className={`p-1 transition-colors ${simulate ? 'text-amber-400 hover:text-amber-300' : 'hover:text-white/80'}`}
+          >
+            <Zap className="w-3.5 h-3.5" fill={simulate ? 'currentColor' : 'none'} />
+          </button>
           <button
             onClick={() => setPaused(!paused)}
             className="p-1 hover:text-white/80 transition-colors"

--- a/services/dashboard/src/components/console/ConsoleToolbar.tsx
+++ b/services/dashboard/src/components/console/ConsoleToolbar.tsx
@@ -2,16 +2,22 @@
 
 import { useState, useEffect } from 'react'
 import { useConsole, type Protocol } from './ConsoleProvider'
-import { Pause, Play, Trash2, ChevronDown, ChevronUp, Search } from 'lucide-react'
+import { Pause, Play, Trash2, ChevronDown, ChevronUp, Search, Maximize2, Minimize2 } from 'lucide-react'
 
 const PROTOCOL_COLORS: Record<Protocol, { bg: string; text: string; label: string }> = {
-  osc: { bg: 'bg-cyan-500/20', text: 'text-cyan-400', label: 'OSC' },
-  mqtt: { bg: 'bg-emerald-500/20', text: 'text-emerald-400', label: 'MQTT' },
-  ws: { bg: 'bg-violet-500/20', text: 'text-violet-400', label: 'WS' },
-  internal: { bg: 'bg-slate-500/20', text: 'text-slate-400', label: 'INT' },
+  osc:      { bg: 'bg-cyan-500/20',    text: 'text-cyan-400',    label: 'OSC'  },
+  mqtt:     { bg: 'bg-emerald-500/20', text: 'text-emerald-400', label: 'MQTT' },
+  ws:       { bg: 'bg-violet-500/20',  text: 'text-violet-400',  label: 'WS'   },
+  dmx:      { bg: 'bg-amber-500/20',   text: 'text-amber-400',   label: 'DMX'  },
+  internal: { bg: 'bg-slate-500/20',   text: 'text-slate-400',   label: 'INT'  },
 }
 
-export function ConsoleToolbar() {
+interface ConsoleToolbarProps {
+  isFullscreen?: boolean
+  onToggleFullscreen?: () => void
+}
+
+export function ConsoleToolbar({ isFullscreen = false, onToggleFullscreen }: ConsoleToolbarProps) {
   const {
     mode, setMode, filters, setFilters,
     paused, setPaused, stats, isConnected, clear,
@@ -40,7 +46,7 @@ export function ConsoleToolbar() {
 
   const isAmbient = mode === 'ambient'
 
-  // Ambient mode: compact floating toolbar
+  // Ambient mode: compact floating overlay
   if (isAmbient) {
     return (
       <div className="absolute top-0 left-0 right-0 z-10 flex items-center justify-between px-4 h-10 bg-transparent text-slate-400/60 transition-opacity hover:opacity-100 opacity-60">
@@ -63,6 +69,23 @@ export function ConsoleToolbar() {
           >
             Debug
           </button>
+          {onToggleFullscreen && (
+            <>
+              {isFullscreen && (
+                <span className="text-[10px] font-mono text-slate-600/70 select-none">ESC</span>
+              )}
+              <button
+                onClick={onToggleFullscreen}
+                className="p-1 hover:text-white/80 transition-colors"
+                title={isFullscreen ? 'Exit fullscreen (ESC)' : 'Fullscreen'}
+              >
+                {isFullscreen
+                  ? <Minimize2 className="w-3.5 h-3.5" />
+                  : <Maximize2 className="w-3.5 h-3.5" />
+                }
+              </button>
+            </>
+          )}
         </div>
       </div>
     )
@@ -124,13 +147,13 @@ export function ConsoleToolbar() {
 
         <div className="flex-1" />
 
-        {/* Mode toggle — visually isolated */}
+        {/* Mode toggle */}
         <div className="flex items-center gap-2 pl-3 border-l border-slate-600">
           {!hintDismissed && (
             <div className="relative">
               <div className="absolute bottom-full right-0 mb-2 w-48 p-2 text-xs bg-slate-700 rounded-lg shadow-lg border border-slate-600 text-slate-300">
                 <p><strong>Debug</strong> = message inspector</p>
-                <p><strong>Ambient</strong> = data art visualization</p>
+                <p><strong>Ambient</strong> = live data visualization</p>
                 <button onClick={dismissHint} className="mt-1 text-blue-400 hover:underline">Got it</button>
               </div>
             </div>

--- a/services/dashboard/src/components/console/DataConsole.tsx
+++ b/services/dashboard/src/components/console/DataConsole.tsx
@@ -1,6 +1,6 @@
 'use client'
 
-import React, { useState, useEffect, useCallback } from 'react'
+import React, { useState, useEffect, useCallback, useRef } from 'react'
 import { ConsoleProvider, useConsole } from './ConsoleProvider'
 import { ConsoleToolbar } from './ConsoleToolbar'
 import { MessageFeed } from './MessageFeed'
@@ -48,10 +48,29 @@ function ConsoleContent() {
   const [displayMode, setDisplayMode] = useState(mode)
   const [transition, setTransition] = useState<TransitionState>('idle')
   const [opacity, setOpacity] = useState(1)
+  const contentRef = useRef<HTMLDivElement>(null)
+  const [isFullscreen, setIsFullscreen] = useState(false)
+
+  const toggleFullscreen = useCallback(async () => {
+    try {
+      if (!document.fullscreenElement) {
+        await contentRef.current?.requestFullscreen()
+      } else {
+        await document.exitFullscreen()
+      }
+    } catch {
+      // Fullscreen not supported or denied
+    }
+  }, [])
+
+  useEffect(() => {
+    const onFSChange = () => setIsFullscreen(!!document.fullscreenElement)
+    document.addEventListener('fullscreenchange', onFSChange)
+    return () => document.removeEventListener('fullscreenchange', onFSChange)
+  }, [])
 
   const handleModeChange = useCallback(() => {
     if (mode === displayMode) return
-    // Start transition
     setTransition('fading-out')
     setOpacity(0)
   }, [mode, displayMode])
@@ -69,7 +88,6 @@ function ConsoleContent() {
       return () => clearTimeout(timer)
     }
     if (transition === 'switching') {
-      // Next frame: start fading in
       requestAnimationFrame(() => {
         setTransition('fading-in')
         setOpacity(1)
@@ -94,8 +112,10 @@ function ConsoleContent() {
   }, [transition, mode])
 
   return (
-    <div className="flex flex-col h-full">
-      <ConsoleToolbar />
+    // relative: positions ambient toolbar's absolute overlay correctly
+    // bg-[#0a0a0f]: correct dark background when browser fullscreens this element
+    <div ref={contentRef} className="flex flex-col h-full relative bg-[#0a0a0f]">
+      <ConsoleToolbar isFullscreen={isFullscreen} onToggleFullscreen={toggleFullscreen} />
 
       <div
         className="flex-1 flex min-h-0 relative"

--- a/services/dashboard/src/components/console/MessageFeed.tsx
+++ b/services/dashboard/src/components/console/MessageFeed.tsx
@@ -8,16 +8,18 @@ import Link from 'next/link'
 
 // --- Protocol badge colors ---
 const BADGE_STYLES: Record<Protocol, string> = {
-  osc: 'bg-cyan-500/20 text-cyan-400',
-  mqtt: 'bg-emerald-500/20 text-emerald-400',
-  ws: 'bg-violet-500/20 text-violet-400',
+  osc:      'bg-cyan-500/20 text-cyan-400',
+  mqtt:     'bg-emerald-500/20 text-emerald-400',
+  ws:       'bg-violet-500/20 text-violet-400',
+  dmx:      'bg-amber-500/20 text-amber-400',
   internal: 'bg-slate-500/20 text-slate-400',
 }
 
 const BADGE_LABELS: Record<Protocol, string> = {
-  osc: 'OSC',
-  mqtt: 'MQTT',
-  ws: 'WS',
+  osc:      'OSC',
+  mqtt:     'MQTT',
+  ws:       'WS',
+  dmx:      'DMX',
   internal: 'INT',
 }
 


### PR DESCRIPTION
## Summary

- **Live ambient visualization** for the Console → Ambient tab — replaces the stub with a real-time canvas showing all gateways (OSC, MQTT, WebSocket, DMX), the NATS bus, entities, devices, and Art-Net nodes
- **Two-hop particle routing** accurately reflects how NATS works: particles travel gateway → bus, then bus → entity on arrive; DMX output shows a secondary hop from DMX gateway → Art-Net node
- **DMX gateway + Art-Net nodes** integrated into topology; entity state updates for DMX-linked entities also animate the full chain through to the hardware node
- **Simulate live data** toggle (⚡ button in the ambient toolbar) — injects realistic synthetic traffic across all protocols using real entity slugs and Art-Net universe numbers from your configured system
- **Fullscreen** support via native browser Fullscreen API; ESC to exit; Minimize/Maximize icons in both debug and ambient toolbars
- **Activity-based node drift** — entity/device/artnet nodes drift outward between two boundary rings when idle, pulled back inward by message activity; frequently active nodes cluster at the inner ring
- **Calibrated MPS heat glow** behind the NATS bus — samples message rate over a 5-minute rolling window and maps current rate to a cool (blue) → warm (orange) color using the observed 10th–90th percentile range, so it works in both low- and high-traffic scenarios
- **DMX protocol** added throughout: `Protocol` type, badge colors, filter pill, particle colors
- **Entity slug routing** fixed — `GraphNode` now carries `slug` field so `resolveSourceTarget` correctly matches real NATS entity state subjects to outer-ring nodes
- **Entity/device labels** always visible (dim at rest, bright when active)

## Test plan

- [ ] Navigate to Console → Ambient tab; verify all gateways and NATS bus appear
- [ ] Toggle ⚡ Simulate — confirm particles flow gateway → bus → entity and DMX gateway → Art-Net node
- [ ] Turn simulate off; send a real MQTT or OSC message; verify correct particle path
- [ ] If DMX nodes configured: send entity state update for a DMX-linked entity; verify secondary amber particle fires to the Art-Net node
- [ ] Click fullscreen button; verify browser goes fullscreen; ESC exits
- [ ] Let the system run idle — verify entity nodes drift toward outer boundary ring; send messages — verify nodes pull back inward
- [ ] Watch the bus glow over several minutes of varied traffic; verify color shifts cool → warm with load

🤖 Generated with [Claude Code](https://claude.com/claude-code)