### PR TITLE
fix(ci): repair OpenAPI export stubs + dashboard smoke-test readiness

### DIFF
--- a/.github/workflows/deploy-test.yml
+++ b/.github/workflows/deploy-test.yml
@@ -73,6 +73,18 @@ jobs:
             sleep 5
           done
 
+          # Check dashboard — it runs `next dev`, which boots and then
+          # compiles the page on first request, so it lags the API.
+          echo "Checking Dashboard..."
+          for i in {1..24}; do
+            if curl -s -o /dev/null http://localhost:3001; then
+              echo "Dashboard is responding"
+              break
+            fi
+            echo "Waiting for Dashboard... ($i/24)"
+            sleep 5
+          done
+
       - name: Show container status on failure
         if: failure()
         run: |
@@ -87,9 +99,10 @@ jobs:
 
       - name: Run smoke tests
         run: |
-          # Basic health checks
+          # Basic health checks. Retry the dashboard on connection errors —
+          # next dev can still be compiling the first request.
           curl -f http://localhost:8080/health || exit 1
-          curl -f http://localhost:3001 || exit 1
+          curl -f --retry 12 --retry-delay 5 --retry-all-errors http://localhost:3001 || exit 1
           echo "Smoke tests passed!"
 
       - name: Cleanup old images

--- a/services/fleet-manager/export_openapi.py
+++ b/services/fleet-manager/export_openapi.py
@@ -54,6 +54,9 @@ db_mod.DeviceProvisionDB = _make_stub_class("DeviceProvisionDB", [
 db_mod.StreamTypeDB = _make_stub_class("StreamTypeDB", [
     "id", "name", "display_name", "description", "icon",
     "default_config", "stream_type_metadata", "created_at", "updated_at"])
+db_mod.OscMappingDB = _make_stub_class("OscMappingDB", [
+    "id", "osc_address", "entity_slug", "state_key", "state_keys",
+    "operation", "enabled", "description", "created_at", "updated_at"])
 sys.modules["database"] = db_mod
 
 # state_manager.py
@@ -71,11 +74,18 @@ stm_mod.stream_manager = type("STM", (), {
 })()
 sys.modules["stream_manager"] = stm_mod
 
-# redis_client.py
+# redis_client.py — stub every public helper so routers/state_manager can
+# import by name without a live Redis. Keep in sync with redis_client.py's
+# module-level functions.
 rc_mod = types.ModuleType("redis_client")
 rc_mod.init_redis = None
 rc_mod.close_redis = None
 rc_mod.get_redis = lambda: None
+rc_mod.cache_entity_state = None
+rc_mod.get_cached_entity_state = None
+rc_mod.invalidate_entity_state_cache = None
+rc_mod.cache_entity_metadata = None
+rc_mod.get_cached_entity_metadata = None
 sys.modules["redis_client"] = rc_mod
 
 # cloud_manager.py — depends on httpx and redis.asyncio


### PR DESCRIPTION
Fixes the two red checks blocking the v0.22.0.0 release ([#61](https://github.com/jordansnyder/maestra-core/pull/61)). Both are pre-existing CI issues, not regressions.

## OpenAPI export (deploy-docs `build` job)
`export_openapi.py` stubs external modules so the FastAPI app imports without live services. The stubs drifted from the code:
- `redis_client` stub was missing the entity-cache helpers added with Redis caching (`get_cached_entity_state`, `invalidate_entity_state_cache`, `cache_entity_metadata`, `get_cached_entity_metadata`, `cache_entity_state`).
- `database` stub was missing `OscMappingDB`.

Result was `ImportError: cannot import name ... (unknown location)`. Added the missing stubs. Validated locally in a clean venv — export now emits a full spec (139 paths).

## Dashboard smoke test (deploy-test `Build and Deploy`)
The wait step waited for Postgres + Fleet Manager but not the dashboard, which runs `next dev` and compiles on first request. The smoke `curl localhost:3001` hit a not-ready server (connection reset). Added a dashboard readiness wait loop and `--retry-all-errors` on the smoke curl.

No application code changed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)