### PR TITLE
fix(dashboard): resolve all 29 TypeScript errors (unblocks production build + smoke test)

### DIFF
--- a/services/dashboard/package-lock.json
+++ b/services/dashboard/package-lock.json
@@ -24,6 +24,8 @@
       "devDependencies": {
         "@testing-library/jest-dom": "^6.9.1",
         "@testing-library/react": "^16.3.2",
+        "@types/d3-force": "^3.0.10",
+        "@types/d3-selection": "^3.0.11",
         "@types/node": "^20",
         "@types/react": "^18",
         "@types/react-dom": "^18",
@@ -1263,6 +1265,13 @@
       "integrity": "sha512-NcV1JjO5oDzoK26oMzbILE6HW7uVXOHLQvHshBUW4UMdZGfiY6v5BeQwh9a9tCzv+CeefZQHJt5SRgK154RtiA==",
       "license": "MIT"
     },
+    "node_modules/@types/d3-force": {
+      "version": "3.0.10",
+      "resolved": "https://registry.npmjs.org/@types/d3-force/-/d3-force-3.0.10.tgz",
+      "integrity": "sha512-ZYeSaCF3p73RdOKcjj+swRlZfnYpK1EbaDiYICEEp5Q6sUiqFaFQ9qgoshp5CzIyyb/yD09kD9o2zEltCexlgw==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/@types/d3-interpolate": {
       "version": "3.0.4",
       "resolved": "https://registry.npmjs.org/@types/d3-interpolate/-/d3-interpolate-3.0.4.tgz",
@@ -1286,6 +1295,13 @@
       "dependencies": {
         "@types/d3-time": "*"
       }
+    },
+    "node_modules/@types/d3-selection": {
+      "version": "3.0.11",
+      "resolved": "https://registry.npmjs.org/@types/d3-selection/-/d3-selection-3.0.11.tgz",
+      "integrity": "sha512-bhAXu23DJWsrI45xafYpkQ4NtcKMwWnAC/vKrd2l+nxMFuvOT3XMYTIj2opv8vq8AO5Yh7Qac/nSeP/3zjTK0w==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/@types/d3-shape": {
       "version": "3.1.7",
@@ -5323,7 +5339,6 @@
       "integrity": "sha512-z6JOK5gRO7aMybVq/y/MlIpKh8JIi68FBKMUtKkK2KH/wMSRlCxQ682d08LB9fYXplyY/UXG8P4XXTScmdjApg==",
       "dev": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "@asamuzakjp/css-color": "^5.0.1",
         "@asamuzakjp/dom-selector": "^7.0.3",

--- a/services/dashboard/package.json
+++ b/services/dashboard/package.json
@@ -27,6 +27,8 @@
   "devDependencies": {
     "@testing-library/jest-dom": "^6.9.1",
     "@testing-library/react": "^16.3.2",
+    "@types/d3-force": "^3.0.10",
+    "@types/d3-selection": "^3.0.11",
     "@types/node": "^20",
     "@types/react": "^18",
     "@types/react-dom": "^18",

--- a/services/dashboard/src/app/dmx/page.tsx
+++ b/services/dashboard/src/app/dmx/page.tsx
@@ -832,7 +832,7 @@ export default function DMXPage() {
           fixtures={fixtures}
           groups={groups}
           defaultPosition={{ x: 300 + fixtures.length * 30, y: 200 + fixtures.length * 20 }}
-          onSubmit={createFixture}
+          onSubmit={async (data) => { await createFixture(data) }}
           onClose={() => setShowAddFixture(false)}
         />
       )}

--- a/services/dashboard/src/app/page.tsx
+++ b/services/dashboard/src/app/page.tsx
@@ -122,6 +122,7 @@ const CATEGORY_COLORS: Record<ActivityCategory, string> = {
   entity: 'border-accent',
   route: 'border-purple-600',
   system: 'border-edge-strong',
+  cloud: 'border-info',
 }
 
 function formatRelativeTime(date: Date): string {

--- a/services/dashboard/src/app/show-control/page.tsx
+++ b/services/dashboard/src/app/show-control/page.tsx
@@ -263,7 +263,7 @@ export default function ShowControlPage() {
                   </span>
                   <span className="flex items-center gap-1.5">
                     <span className="w-2 h-2 rounded-full bg-yellow-500" />
-                    {devices.filter(d => d.status === 'stale' || d.status === 'checking').length} warning
+                    {devices.filter(d => d.status === 'maintenance' || d.status === 'pending').length} warning
                   </span>
                   <span className="flex items-center gap-1.5">
                     <span className="w-2 h-2 rounded-full bg-red-500" />

--- a/services/dashboard/src/components/console/ConsoleProvider.tsx
+++ b/services/dashboard/src/components/console/ConsoleProvider.tsx
@@ -280,7 +280,7 @@ export function ConsoleProvider({ children }: { children: React.ReactNode }) {
       ]
       try {
         const devices = await api.listDevices()
-        devices.forEach((d: Device) => {
+        devices.forEach((d) => {
           graphNodes.push({ id: d.id, label: d.name, type: 'device', activity: 0 })
         })
       } catch {

--- a/services/dashboard/src/components/console/ConsoleToolbar.tsx
+++ b/services/dashboard/src/components/console/ConsoleToolbar.tsx
@@ -177,9 +177,7 @@ export function ConsoleToolbar({ isFullscreen = false, onToggleFullscreen }: Con
             </button>
             <button
               onClick={() => setMode('ambient')}
-              className={`px-3 py-1 text-xs font-medium rounded-md transition-colors ${
-                mode === 'ambient' ? 'bg-purple-600 text-fg' : 'text-fg-muted hover:text-fg'
-              }`}
+              className="px-3 py-1 text-xs font-medium rounded-md transition-colors text-fg-muted hover:text-fg"
             >
               Ambient
             </button>

--- a/services/dashboard/src/components/dmx/DMXChannelPanel.tsx
+++ b/services/dashboard/src/components/dmx/DMXChannelPanel.tsx
@@ -24,7 +24,7 @@ export function DMXChannelPanel({ fixture, currentState, onStateChange }: DMXCha
     .map(([varName, mapping]) => ({
       varName,
       offset: mapping.offset,
-      label: (mapping as Record<string, unknown>)['label'] as string ?? varName,
+      label: mapping.label ?? varName,
       type: mapping.type,
     }))
     .sort((a, b) => a.offset - b.offset)

--- a/services/dashboard/src/components/settings/DMXGatewaySettings.tsx
+++ b/services/dashboard/src/components/settings/DMXGatewaySettings.tsx
@@ -180,7 +180,7 @@ export function DMXGatewaySettings() {
                             style={{ background: u.color ?? '#64748b' }}
                           />
                           U{u.id}
-                          {u.label ? ` · ${u.label}` : ''}
+                          {u.port_label ? ` · ${u.port_label}` : ''}
                         </span>
                       ))}
                     </div>

--- a/services/dashboard/src/components/settings/SettingsPage.tsx
+++ b/services/dashboard/src/components/settings/SettingsPage.tsx
@@ -16,7 +16,7 @@ export function SettingsPage() {
   const [tab, setTab] = useState<Tab>('general')
   const cloud = useCloudGateway(true, 15000)
 
-  const isConnected = cloud.config?.gateway_url && cloud.config.status !== 'disconnected'
+  const isConnected = !!(cloud.config?.gateway_url && cloud.config.status !== 'disconnected')
 
   return (
     <div className="p-6 max-w-4xl mx-auto space-y-6">

--- a/services/dashboard/src/hooks/useActivityFeed.ts
+++ b/services/dashboard/src/hooks/useActivityFeed.ts
@@ -15,10 +15,24 @@ export interface ActivityItem {
 
 let idCounter = 0
 
+/** Loosely-typed view of a WebSocket message payload (dynamic JSON). */
+interface ActivityData {
+  message?: string
+  entity_slug?: string
+  slug?: string
+  changed_keys?: string[]
+  device_name?: string
+  name?: string
+  severity?: string
+  site_slug?: string
+  from?: string
+  to?: string
+}
+
 function parseMessage(msg: WebSocketMessage): ActivityItem | null {
   const timestamp = new Date(msg.timestamp || Date.now())
   const subject = msg.subject || ''
-  const data = msg.data || {}
+  const data = (msg.data || {}) as ActivityData
 
   // Welcome / connection messages
   if (msg.type === 'welcome') {

--- a/services/dashboard/src/hooks/useSequencePlayback.ts
+++ b/services/dashboard/src/hooks/useSequencePlayback.ts
@@ -121,7 +121,7 @@ export function useSequencePlayback() {
   useEffect(() => {
     const unsub = subscribeToWsMessages((msg) => {
       if (msg.subject !== 'maestra.dmx.playback.status') return
-      const data = msg.data
+      const data = msg.data as { type?: string; engines?: RawEngineStatus[] } | undefined
       if (!data || data.type !== 'playback_status' || !Array.isArray(data.engines)) return
 
       lastWsPushRef.current = Date.now()


### PR DESCRIPTION
Makes the dashboard production build (`next build`) pass, which fixes the chronically-red `deploy-test` smoke test (it runs `npm run build && npm run start`).

## Root cause
The smoke test builds production, but the shipped GHCR image runs `next dev` (no type-checking). So 29 type errors accumulated unseen and broke `next build` — nothing served on :3001, smoke test red for months. None were caused by the brand rebrand.

## Fixes (29 errors)
- `@types/d3-force` + `@types/d3-selection` (NetworkGraph) — 4
- Typed the dynamic WebSocket payloads in `useActivityFeed`/`useSequencePlayback` — 17
- `CATEGORY_COLORS` missing `cloud` key
- show-control warning count used invalid statuses `stale`/`checking` (always 0) → `maintenance`/`pending` (latent bug)
- ConsoleProvider stale `Device` annotation clashing with the api return type
- ConsoleToolbar dead `mode === ambient` check after the ambient early-return
- DMXChannelPanel bad cast (ChannelMapping already has `label`)
- DMXGatewaySettings `u.label` → `u.port_label`
- SettingsPage coerce `isConnected` to boolean

## Verification
`npx tsc --noEmit` → 0 errors. `next build` → all 12 routes build successfully.

No styling/behavior changes (except fixing the always-0 warning count and removing dead code).

🤖 Generated with [Claude Code](https://claude.com/claude-code)