### PR TITLE
ci: suspend auto-runs of Deploy to Test Environment

### DIFF
--- a/.github/workflows/deploy-test.yml
+++ b/.github/workflows/deploy-test.yml
@@ -1,9 +1,14 @@
 name: Deploy to Test Environment
 
+# Suspended from automatic runs. This job stands up the full stack and runs a
+# production dashboard build (`npm run build`) at container startup, which is
+# resource-heavy and unreliable on the shared GitHub runner (the build doesn't
+# finish within the readiness window under full-stack load). It has been red for
+# a long time and gives a false signal on every develop push. Run it manually
+# from the Actions tab against a suitable test environment when needed; re-enable
+# the push trigger once it has a dedicated runner.
 on:
-  push:
-    branches:
-      - develop
+  workflow_dispatch:
 
 env:
   COMPOSE_PROJECT_NAME: maestra-test


### PR DESCRIPTION
Switches the `Deploy to Test Environment` workflow to `workflow_dispatch` (manual) only, so it stops reporting a false failure on every develop push.

It builds the full stack and runs a production dashboard build at container startup, which is resource-heavy and unreliable on the shared GitHub runner (the build does not finish within the readiness window under full-stack load). Red for months. Can still be run manually from the Actions tab; re-enable the push trigger once it has a dedicated test runner.

The build/smoke logic is left intact (including the earlier readiness-wait improvements) for when it runs on a real environment.

🤖 Generated with [Claude Code](https://claude.com/claude-code)