### PR TITLE
Promote desktop v0.2.2 to main (auto-update enabled)

### DIFF
--- a/desktop/package.json
+++ b/desktop/package.json
@@ -1,7 +1,7 @@
 {
   "name": "maestra-desktop",
   "private": true,
-  "version": "0.2.1",
+  "version": "0.2.2",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/desktop/package.json
+++ b/desktop/package.json
@@ -1,7 +1,7 @@
 {
   "name": "maestra-desktop",
   "private": true,
-  "version": "0.2.0",
+  "version": "0.2.1",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/desktop/package.json
+++ b/desktop/package.json
@@ -1,7 +1,7 @@
 {
   "name": "maestra-desktop",
   "private": true,
-  "version": "0.1.0",
+  "version": "0.2.0",
   "type": "module",
   "scripts": {
     "dev": "vite",

--- a/desktop/src-tauri/Cargo.lock
+++ b/desktop/src-tauri/Cargo.lock
@@ -1926,7 +1926,7 @@ checksum = "c41e0c4fef86961ac6d6f8a82609f55f31b05e4fce149ac5710e439df7619ba4"
 
 [[package]]
 name = "maestra-desktop"
-version = "0.2.0"
+version = "0.2.1"
 dependencies = [
  "dirs 5.0.1",
  "include_dir",

--- a/desktop/src-tauri/Cargo.lock
+++ b/desktop/src-tauri/Cargo.lock
@@ -1926,7 +1926,7 @@ checksum = "c41e0c4fef86961ac6d6f8a82609f55f31b05e4fce149ac5710e439df7619ba4"
 
 [[package]]
 name = "maestra-desktop"
-version = "0.2.1"
+version = "0.2.2"
 dependencies = [
  "dirs 5.0.1",
  "include_dir",

--- a/desktop/src-tauri/Cargo.lock
+++ b/desktop/src-tauri/Cargo.lock
@@ -1926,7 +1926,7 @@ checksum = "c41e0c4fef86961ac6d6f8a82609f55f31b05e4fce149ac5710e439df7619ba4"
 
 [[package]]
 name = "maestra-desktop"
-version = "0.1.0"
+version = "0.2.0"
 dependencies = [
  "dirs 5.0.1",
  "include_dir",

--- a/desktop/src-tauri/Cargo.toml
+++ b/desktop/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "maestra-desktop"
-version = "0.1.0"
+version = "0.2.0"
 description = "Maestra Desktop — one-click launcher for the Maestra creative platform"
 authors = ["Jordan Snyder"]
 edition = "2021"

--- a/desktop/src-tauri/Cargo.toml
+++ b/desktop/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "maestra-desktop"
-version = "0.2.0"
+version = "0.2.1"
 description = "Maestra Desktop — one-click launcher for the Maestra creative platform"
 authors = ["Jordan Snyder"]
 edition = "2021"

--- a/desktop/src-tauri/Cargo.toml
+++ b/desktop/src-tauri/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "maestra-desktop"
-version = "0.2.1"
+version = "0.2.2"
 description = "Maestra Desktop — one-click launcher for the Maestra creative platform"
 authors = ["Jordan Snyder"]
 edition = "2021"

--- a/desktop/src-tauri/src/docker.rs
+++ b/desktop/src-tauri/src/docker.rs
@@ -328,16 +328,28 @@ pub async fn start_services(app: AppHandle, profile: String) -> Result<(), Docke
         Some(profile.as_str())
     };
 
-    // Pre-flight: check if images are present
+    // Pre-flight: always pull so `:latest` images stay current. The services
+    // are published to GHCR as `:latest`, and Docker will not re-pull a tag it
+    // already has locally — so only pulling when images are *missing* (the old
+    // behavior) left users stuck on stale cached images forever. `docker compose
+    // pull` only downloads layers that actually changed, so this is cheap when
+    // already up to date.
+    //
+    // Offline-safe: if the pull fails but every image is already present
+    // locally, fall back to the cached images instead of blocking startup. When
+    // images are missing we still hard-fail (we can't start without them). To
+    // keep offline startup fast, only retry when we actually need the images.
     let image_status = crate::setup::check_images_present_inner(&app, &profile).await;
-    if let Ok(ref status) = image_status {
-        if !status.all_present && !status.missing.is_empty() {
-            // Auto-pull missing images before starting
-            let _ = app.emit("start-progress", "Downloading missing services...");
-            let pull_result = pull_images_inner(&app, &profile, 5).await;
-            if let Err(e) = pull_result {
-                return Err(e);
-            }
+    let all_present = image_status.as_ref().map(|s| s.all_present).unwrap_or(false);
+
+    let pull_attempts = if all_present { 1 } else { 5 };
+    let _ = app.emit("start-progress", "Checking for service updates...");
+    if let Err(e) = pull_images_inner(&app, &profile, pull_attempts).await {
+        if all_present {
+            // Registry unreachable (e.g. offline) but we can run on what we have.
+            let _ = app.emit("start-progress", "Using cached images (couldn't reach registry).");
+        } else {
+            return Err(e);
         }
     }
 

--- a/desktop/src-tauri/tauri.conf.json
+++ b/desktop/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://raw.githubusercontent.com/nicegui-org/nicegui/main/tauri/schemas/tauri.conf.json",
   "productName": "Maestra",
-  "version": "0.1.0",
+  "version": "0.2.0",
   "identifier": "com.maestra.desktop",
   "build": {
     "beforeDevCommand": "npm run dev",
@@ -33,7 +33,7 @@
   "bundle": {
     "active": true,
     "targets": "all",
-    "createUpdaterArtifacts": true,
+    "createUpdaterArtifacts": false,
     "icon": [
       "icons/32x32.png",
       "icons/128x128.png",

--- a/desktop/src-tauri/tauri.conf.json
+++ b/desktop/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://raw.githubusercontent.com/nicegui-org/nicegui/main/tauri/schemas/tauri.conf.json",
   "productName": "Maestra",
-  "version": "0.2.0",
+  "version": "0.2.1",
   "identifier": "com.maestra.desktop",
   "build": {
     "beforeDevCommand": "npm run dev",

--- a/desktop/src-tauri/tauri.conf.json
+++ b/desktop/src-tauri/tauri.conf.json
@@ -1,7 +1,7 @@
 {
   "$schema": "https://raw.githubusercontent.com/nicegui-org/nicegui/main/tauri/schemas/tauri.conf.json",
   "productName": "Maestra",
-  "version": "0.2.1",
+  "version": "0.2.2",
   "identifier": "com.maestra.desktop",
   "build": {
     "beforeDevCommand": "npm run dev",
@@ -33,7 +33,7 @@
   "bundle": {
     "active": true,
     "targets": "all",
-    "createUpdaterArtifacts": false,
+    "createUpdaterArtifacts": true,
     "icon": [
       "icons/32x32.png",
       "icons/128x128.png",


### PR DESCRIPTION
Promotes the desktop app changes from develop to main so the release is cut from main (the stable/released line).

Brings desktop v0.2.0 → v0.2.2:
- v0.2.0/v0.2.1: version bumps + the always-pull-images fix on start.
- v0.2.2: re-enables `createUpdaterArtifacts` (signing key now configured) for working auto-update.

Desktop-only changeset — no `services/` or core `VERSION` changes, so `publish-docker-images` does not trigger. After merge, tag `desktop/v0.2.2` from main to build/release.

🤖 Generated with [Claude Code](https://claude.com/claude-code)